### PR TITLE
Depend on temporary mitm-mwoc fork of mitm, which has two fixes for event timing

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1,6 +1,6 @@
 /* global setImmediate, after, console */
 var messy = require('messy'),
-    createMitm = require('mitm'),
+    createMitm = require('mitm-mwoc'),
     async = require('async'),
     _ = require('underscore'),
     http = require('http'),

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "detect-indent": "3.0.0",
     "memoizesync": "0.5.0",
     "messy": "^6.6.1",
-    "mitm": "1.2.0",
+    "mitm-mwoc": "1.3.0",
     "passerror": "1.1.0",
     "underscore": "1.7.0",
     "unexpected-messy": "^5.0.0"


### PR DESCRIPTION
Awaiting pull requests https://github.com/moll/node-mitm/pull/24 and https://github.com/moll/node-mitm/pull/25, it would be good to get a version of unexpected-mitm out that includes those fixes.