### PR TITLE
Use raw data in response function connection hook to build mockResponse.

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -170,12 +170,7 @@ function resolveExpectedRequestProperties(expectedRequestProperties) {
 }
 
 function createMockResponse(responseProperties) {
-    if (responseProperties instanceof http.ServerResponse) {
-        responseProperties = {
-            headers: responseProperties._headers
-        };
-    }
-    if (responseProperties && responseProperties.body && (typeof responseProperties.body === 'string' || (typeof Buffer !== 'undefined' && Buffer.isBuffer(responseProperties.body)))) {
+    if (typeof responseProperties === 'object' && responseProperties.body && (typeof responseProperties.body === 'string' || (typeof Buffer !== 'undefined' && Buffer.isBuffer(responseProperties.body)))) {
         responseProperties = _.extend({}, responseProperties);
         responseProperties.unchunkedBody = responseProperties.body;
         delete responseProperties.body;
@@ -188,44 +183,68 @@ function createMockResponse(responseProperties) {
     return mockResponse;
 }
 
+function hasTrailerChunk(chunk) {
+    return isTrailerChunk(chunk.slice(-5));
+}
+
+function isTrailerChunk(chunk) {
+    return chunk === '0\r\n\r\n';
+}
+
+function attachConnectionHook(connection, callback) {
+    var isFirst = true;
+    var rawChunks = [];
+    var _write = connection._write;
+
+    /*
+     * wrap low level write to gather response data and return raw data
+     * to callback when entire response is written
+     */
+    connection._write = function (chunk, encoding, cb) {
+        var isBuffer = Buffer.isBuffer(chunk);
+
+        rawChunks.push(isBuffer ? chunk : new Buffer(chunk));
+
+        if (isTrailerChunk(chunk) || hasTrailerChunk(chunk)) {
+            /*
+             * explicitly execute the callback returning raw data here
+             * to ensure it is run before issuing the final write which
+             * will complete the request on the wire
+             */
+            callback(null, Buffer.concat(rawChunks));
+        }
+
+        isFirst = false;
+
+        _write.call(connection, chunk, encoding, cb);
+    };
+}
+
 function attachResponseHooks(res, callback) {
     var hasEnded = false; // keep track of whether res.end() has been called
-    var seenChunks = [];
 
-    ['write', 'end', 'destroy'].forEach(function (methodName) {
+    attachConnectionHook(res.connection, function (err, rawBuffer) {
+        if (hasEnded) {
+            callback(null, rawBuffer);
+        }
+    });
+
+    ['end', 'destroy'].forEach(function (methodName) {
         var orig = res[methodName];
         res[methodName] = function (chunk, encoding) {
-            /*
-             * store any data chunk that passed through
-             *
-             * this is done only before the ended flag is set to
-             * avoid duplicating chunks in the case of further
-             * res.write() calls resulting from res.end(chunk)
-             */
-            if (!hasEnded && chunk) {
-                seenChunks.push(Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk));
-            }
-
             if (methodName === 'end') {
                 hasEnded = true;
-                /*
-                 * explicitly execute the callback to return the body here
-                 * to ensure it is run before calling the res.end() which
-                 * will complete the request on the wire
-                 */
-                callback(null, Buffer.concat(seenChunks));
             }
 
             var returnValue = orig.apply(this, arguments);
 
             if (methodName === 'destroy') {
-                callback();
+                hasEnded = true;
+                callback(null);
             }
 
-            // Don't attempt to implement backpressure, since we're buffering the entire response anyway.
-            if (methodName !== 'write') {
-                return returnValue;
-            }
+            // unconditionally return value given we do not wrap write
+            return returnValue;
         };
     });
 }
@@ -670,14 +689,13 @@ module.exports = {
                             }
 
                             /*
-                             * hook end() callback to record buffered data and immediately
+                             * hook final write callback to record raw data and immediately
                              * assert request so it occurs prior to request completion
                              */
-                            attachResponseHooks(res, passError(handleError, function (dataBuffer) {
-                                var mockResponse = createMockResponse(res);
-                                mockResponse.unchunkedBody = dataBuffer;
-                                assertMockResponse(mockResponse, undefined, passError(handleError, function () {}));
-                            }));
+                             attachResponseHooks(res, passError(handleError, function (rawBuffer) {
+                                 var mockResponse = createMockResponse(rawBuffer);
+                                 assertMockResponse(mockResponse, undefined, passError(handleError, function () {}));
+                             }));
 
                             if (typeof responseProperties === 'function') {
                                 // call response function inside a promise to catch exceptions

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -16,6 +16,7 @@ function trimDiff(message) {
     message = message.replace(/^[\\ ]*Date:.*\n/gm, '');
     message = message.replace(/^[\\ ]*Connection:.*\n/gm, '');
     message = message.replace(/^[\\ ]*Transfer-Encoding:.*\n?/gm, '');
+    message = message.replace(/^[\\ ]*Content-Length: 0\n?/gm, '');
     message = message.replace(/HTTP\/1.1 200 OK\n$/, 'HTTP/1.1 200 OK');
 
     return message;
@@ -286,7 +287,6 @@ describe('unexpectedMitm', function () {
                             '\n' +
                             'GET / HTTP/1.1\n' +
                             'Host: www.google.com\n' +
-                            'Content-Length: 0\n' +
                             '// expected an encrypted request\n' +
                             '\n' +
                             'HTTP/1.1 200 OK'
@@ -317,7 +317,6 @@ describe('unexpectedMitm', function () {
                             '\n' +
                             'GET / HTTP/1.1\n' +
                             'Host: www.google.com\n' +
-                            'Content-Length: 0\n' +
                             '// expected an encrypted request\n' +
                             '\n' +
                             'HTTP/1.1 200 OK'
@@ -354,7 +353,6 @@ describe('unexpectedMitm', function () {
                         'Host: www.google.com // should equal www.example.com\n' +
                         '                     // -www.google.com\n' +
                         '                     // +www.example.com\n' +
-                        'Content-Length: 0\n' +
                         "// host: expected 'www.google.com' to equal 'www.example.com'\n" +
                         '//\n' +
                         '// -www.google.com\n' +
@@ -564,7 +562,6 @@ describe('unexpectedMitm', function () {
                     '                  // -GET /foo HTTP/1.1\n' +
                     '                  // +GET /bar HTTP/1.1\n' +
                     'Host: www.google.com\n' +
-                    'Content-Length: 0\n' +
                     '\n' +
                     'HTTP/1.1 200 OK'
                 );
@@ -592,7 +589,6 @@ describe('unexpectedMitm', function () {
                     '\n' +
                     'GET /foo HTTP/1.1\n' +
                     'Host: www.google.com\n' +
-                    'Content-Length: 0\n' +
                     '\n' +
                     'HTTP/1.1 200 OK\n' +
                     '\n' +
@@ -628,7 +624,6 @@ describe('unexpectedMitm', function () {
                     '\n' +
                     'GET /foo HTTP/1.1\n' +
                     'Host: www.google.com\n' +
-                    'Content-Length: 0\n' +
                     '\n' +
                     'HTTP/1.1 200 OK\n' +
                     '\n' +
@@ -726,7 +721,6 @@ describe('unexpectedMitm', function () {
                     '\n' +
                     '  GET /foo HTTP/1.1\n' +
                     '  Host: www.google.com\n' +
-                    '  Content-Length: 0\n' +
                     '\n' +
                     '  HTTP/1.1 200 OK // should be 412 Precondition Failed\n' +
                     '                  //\n' +
@@ -912,7 +906,6 @@ describe('unexpectedMitm', function () {
                             '\n' +
                             'GET /foo HTTP/1.1\n' +
                             'Host: www.google.com\n' +
-                            'Content-Length: 0\n' +
                             '// key: expected Buffer([0x02]) to equal Buffer([0x05])\n' +
                             '//\n' +
                             '// -02                                               │.│\n' +

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -12,6 +12,15 @@ var pathModule = require('path'),
 
 var isNodeZeroTen = !!process.version.match(/v0.10/);
 
+function trimDiff(message) {
+    message = message.replace(/^[\\ ]*Date:.*\n/gm, '');
+    message = message.replace(/^[\\ ]*Connection:.*\n/gm, '');
+    message = message.replace(/^[\\ ]*Transfer-Encoding:.*\n?/gm, '');
+    message = message.replace(/HTTP\/1.1 200 OK\n$/, 'HTTP/1.1 200 OK');
+
+    return message;
+}
+
 describe('unexpectedMitm', function () {
     var expect = require('unexpected')
         .use(require('../lib/unexpectedMitm'))
@@ -219,7 +228,7 @@ describe('unexpectedMitm', function () {
                 }),
                 'when rejected',
                 'to have message', function (message) {
-                    expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                    expect(trimDiff(message), 'to equal',
                         "expected { url: 'POST http://www.google.com/', body: { foo: 123 } } with http mocked out\n" +
                         "{\n" +
                         "  request: { url: 'POST /', body: expect.it('when delayed a little bit', 'to equal', ...) },\n" +
@@ -272,7 +281,7 @@ describe('unexpectedMitm', function () {
                     }, 'to yield response', 200),
                     'when rejected',
                     'to have message', function (message) {
-                        expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                        expect(trimDiff(message), 'to equal',
                             "expected 'http://www.google.com/' with http mocked out { request: 'GET https://www.google.com/', response: 200 } to yield response 200\n" +
                             '\n' +
                             'GET / HTTP/1.1\n' +
@@ -303,7 +312,7 @@ describe('unexpectedMitm', function () {
                     }, 'to yield response', 200),
                     'when rejected',
                     'to have message', function (message) {
-                        expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                        expect(trimDiff(message), 'to equal',
                             "expected 'http://www.google.com/' with http mocked out { request: { url: 'GET /', encrypted: true }, response: 200 } to yield response 200\n" +
                             '\n' +
                             'GET / HTTP/1.1\n' +
@@ -335,7 +344,7 @@ describe('unexpectedMitm', function () {
                 }, 'to yield response', 200),
                 'when rejected',
                 'to have message', function (message) {
-                    expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                    expect(trimDiff(message), 'to equal',
                         "expected 'http://www.google.com/' with http mocked out { request: 'POST http://www.example.com/', response: 200 } to yield response 200\n" +
                         '\n' +
                         'GET / HTTP/1.1 // should be POST /\n' +
@@ -493,7 +502,7 @@ describe('unexpectedMitm', function () {
                 }, 'to yield response', 200),
                 'when rejected',
                 'to have message', function (message) {
-                    expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                    expect(trimDiff(message), 'to equal',
                         "expected { url: 'POST http://www.google.com/', body: { foo: 123 } }\n" +
                         "with http mocked out { request: { url: 'POST /', body: { foo: 456 } }, response: 200 } to yield response 200\n" +
                         '\n' +
@@ -547,7 +556,7 @@ describe('unexpectedMitm', function () {
             }, 'to yield response', 200),
             'when rejected',
             'to have message', function (message) {
-                expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                expect(trimDiff(message), 'to equal',
                     "expected 'http://www.google.com/foo' with http mocked out { request: 'GET /bar', response: 200 } to yield response 200\n" +
                     '\n' +
                     'GET /foo HTTP/1.1 // should be GET /bar\n' +
@@ -577,7 +586,7 @@ describe('unexpectedMitm', function () {
             ], 'to yield response', 200),
             'when rejected',
             'to have message', function (message) {
-                expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                expect(trimDiff(message), 'to equal',
                     "expected 'http://www.google.com/foo'\n" +
                     "with http mocked out [ { request: 'GET /foo', response: 200 }, { request: 'GET /foo', response: 200 } ] to yield response 200\n" +
                     '\n' +
@@ -613,7 +622,7 @@ describe('unexpectedMitm', function () {
             ], 'to yield response', 200),
             'when rejected',
             'to have message', function (message) {
-                expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                expect(trimDiff(message), 'to equal',
                     "expected 'http://www.google.com/foo'\n" +
                     "with http mocked out [ { request: 'GET /foo', response: 200 }, { request: { url: 'GET /foo', headers: ... }, response: 200 } ] to yield response 200\n" +
                     '\n' +
@@ -657,7 +666,7 @@ describe('unexpectedMitm', function () {
             ], 'to yield response', 200),
             'when rejected',
             'to have message', function (message) {
-                expect(message.replace(/^Connection:.*\n/m, ''), 'to equal',
+                expect(trimDiff(message), 'to equal',
                     "expected { url: 'POST http://www.google.com/foo', body: { foo: 123 } } with http mocked out\n" +
                     "[\n" +
                     "  { request: { url: 'POST /foo', body: expect.it('when delayed a little bit', 'to equal', ...) }, response: 200 },\n" +
@@ -711,18 +720,18 @@ describe('unexpectedMitm', function () {
             }, 'to yield response', 412),
             'when rejected',
             'to have message', function (message) {
-                expect(
-                    message.replace(/\n\s*Content-Length:.*$|^\s*Content-Length:.*\n/gm, '').replace(/^\s*Date:.*\n/m, '').replace(/^\s*Connection:.*\n|\n\s*Connection:.*$/mg, '').replace(/\n\s*Transfer-Encoding:.*$/g, ''), 'to equal',
+                expect(trimDiff(message), 'to equal',
                     "expected 'http://www.google.com/foo' with http mocked out { request: 'GET /foo', response: 200 } to yield response 412\n" +
                     "  expected 'http://www.google.com/foo' to yield response 412\n" +
                     '\n' +
                     '  GET /foo HTTP/1.1\n' +
                     '  Host: www.google.com\n' +
+                    '  Content-Length: 0\n' +
                     '\n' +
                     '  HTTP/1.1 200 OK // should be 412 Precondition Failed\n' +
                     '                  //\n' +
                     '                  // -HTTP/1.1 200 OK\n' +
-                    '                  // +HTTP/1.1 412 Precondition Failed'
+                    '                  // +HTTP/1.1 412 Precondition Failed\n'
             );
             }
         );
@@ -897,9 +906,7 @@ describe('unexpectedMitm', function () {
                     'when rejected',
                     'to have message',
                     function (message) {
-                        expect(
-                            message.replace(/^\s*Date:.*\n/m, '').replace(/^Connection:.*\n/m, ''),
-                            'to equal',
+                        expect(trimDiff(message), 'to equal',
                             "expected { url: 'https://www.google.com/foo', cert: Buffer([0x01]), key: Buffer([0x02]), ca: Buffer([0x03]) }\n" +
                             "with http mocked out { request: { url: 'GET /foo', cert: Buffer([0x01]), key: Buffer([0x05]), ca: Buffer([0x03]) }, response: 200 } to yield response 200\n" +
                             '\n' +


### PR DESCRIPTION
This is some hairy code - but what it does is hook at a very low level to response generation when using response functions and capture the raw data (which ends up as a Buffer). This is then passed directly to the messy.HttpReesponse() constructor for parsing of the complete response.