### PR TITLE
Split the body of mitm execution into a function.

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -384,134 +384,146 @@ module.exports = {
             });
         }
 
+        function executeMitm(expect, subject) {
+            var mitm = createMitm(),
+                callbackCalled = false,
+                recordedExchanges = [];
+
+            return expect.promise(function (resolve, reject) {
+                function cleanUp() {
+                    mitm.disable();
+                }
+
+                function handleError(err) {
+                    if (!callbackCalled) {
+                        callbackCalled = true;
+                        cleanUp();
+                        reject(err);
+                    }
+                }
+
+                var bypassNextConnect = false,
+                    lastHijackedSocket,
+                    lastHijackedSocketOptions;
+
+                mitm.on('connect', function (socket, opts) {
+                    if (bypassNextConnect) {
+                        socket.bypass();
+                        bypassNextConnect = false;
+                    } else {
+                        lastHijackedSocket = socket;
+                        lastHijackedSocketOptions = opts;
+                    }
+                }).on('request', createSerializedRequestHandler(function (req, res) {
+                    var metadata = _.extend(
+                            {},
+                            _.pick(lastHijackedSocketOptions.agent && lastHijackedSocketOptions.agent.options, metadataPropertyNames),
+                            _.pick(lastHijackedSocketOptions, metadataPropertyNames)
+                        ),
+                        recordedExchange = {
+                            request: _.extend({
+                                url: req.method + ' ' + req.url,
+                                headers: formatHeaderObj(req.headers)
+                            }, metadata),
+                            response: {}
+                        };
+                    recordedExchanges.push(recordedExchange);
+                    consumeReadableStream(req, passError(handleError, function (result) {
+                        if (result.error) {
+                            // TODO: Consider adding support for recording this (the request erroring out while we're recording it)
+                            return handleError(result.error);
+                        }
+                        recordedExchange.request.body = result.body;
+                        bypassNextConnect = true;
+                        var matchHostHeader = req.headers.host && req.headers.host.match(/^([^:]*)(?::(\d+))?/),
+                            host,
+                            port;
+
+                        // https://github.com/moll/node-mitm/issues/14
+                        if (matchHostHeader) {
+                            if (matchHostHeader[1]) {
+                                host = matchHostHeader[1];
+                            }
+                            if (matchHostHeader[2]) {
+                                port = parseInt(matchHostHeader[2], 10);
+                            }
+                        }
+                        if (!host) {
+                            return handleError(new Error('unexpected-mitm recording mode: Could not determine the host name from Host header: ' + req.headers.host));
+                        }
+                        (req.socket.encrypted ? https : http).request(_.extend({
+                            method: req.method,
+                            host: host,
+                            port: port || (req.socket.encrypted ? 443 : 80),
+                            headers: req.headers,
+                            path: req.url
+                        }, metadata)).on('response', function (response) {
+                            recordedExchange.response.statusCode = response.statusCode;
+                            recordedExchange.response.headers = formatHeaderObj(response.headers);
+                            consumeReadableStream(response, passError(handleError, function (result) {
+                                if (result.error) {
+                                    // TODO: Consider adding support for recording this (the upstream response erroring out while we're recording it)
+                                    return handleError(result.error);
+                                }
+                                recordedExchange.response.body = result.body;
+                                setImmediate(function () {
+                                    res.statusCode = response.statusCode;
+                                    Object.keys(response.headers).forEach(function (headerName) {
+                                        res.setHeader(headerName, response.headers[headerName]);
+                                    });
+                                    res.end(recordedExchange.response.body);
+                                });
+                            }));
+                        }).on('error', function (err) {
+                            recordedExchange.response = err;
+                            lastHijackedSocket.emit('error', err);
+                        }).end(recordedExchange.request.body);
+                    }));
+                }));
+
+                expect.promise(function () {
+                    return expect.shift();
+                }).caught(handleError).then(function () {
+                    if (!callbackCalled) {
+                        callbackCalled = true;
+                        cleanUp();
+                        recordedExchanges = recordedExchanges.map(trimRecordedExchange);
+                        if (recordedExchanges.length === 1) {
+                            recordedExchanges = recordedExchanges[0];
+                        }
+
+                        resolve(recordedExchanges);
+                    }
+                });
+            });
+        }
+
         var afterBlockRegistered = false;
+
         expect
             .addAssertion('<any> with http recorded [and injected] <assertion>', function (expect, subject) {
                 var stack = callsite(),
-                    mitm = createMitm(),
-                    injectIntoTest = this.flags['and injected'],
-                    callbackCalled = false,
-                    recordedExchanges = [];
+                    injectIntoTest = this.flags['and injected'];
+
+                if (injectIntoTest && !afterBlockRegistered) {
+                    after(applyInjections);
+                    afterBlockRegistered = true;
+                }
 
                 return expect.promise(function (resolve, reject) {
-                    if (injectIntoTest && !afterBlockRegistered) {
-                        after(applyInjections);
-                        afterBlockRegistered = true;
-                    }
-
-                    function cleanUp() {
-                        mitm.disable();
-                    }
-
-                    function handleError(err) {
-                        if (!callbackCalled) {
-                            callbackCalled = true;
-                            cleanUp();
-                            reject(err);
+                    return executeMitm(expect, subject).caught(reject).then(function (recordedExchanges) {
+                        if (injectIntoTest) {
+                            // Find the first call site that has mocha's "test" property:
+                            var containingCallsite = stack.filter(function (parentCallsite) {
+                                return parentCallsite.receiver.test;
+                            }).shift();
+                            var fileName = containingCallsite && containingCallsite.getFileName();
+                            if (fileName) {
+                                injectRecordedExchanges(fileName, recordedExchanges, containingCallsite.pos);
+                            }
                         }
-                    }
 
-                    var bypassNextConnect = false,
-                        lastHijackedSocket,
-                        lastHijackedSocketOptions;
-
-                    mitm.on('connect', function (socket, opts) {
-                        if (bypassNextConnect) {
-                            socket.bypass();
-                            bypassNextConnect = false;
-                        } else {
-                            lastHijackedSocket = socket;
-                            lastHijackedSocketOptions = opts;
-                        }
-                    }).on('request', createSerializedRequestHandler(function (req, res) {
-                        var metadata = _.extend(
-                                {},
-                                _.pick(lastHijackedSocketOptions.agent && lastHijackedSocketOptions.agent.options, metadataPropertyNames),
-                                _.pick(lastHijackedSocketOptions, metadataPropertyNames)
-                            ),
-                            recordedExchange = {
-                                request: _.extend({
-                                    url: req.method + ' ' + req.url,
-                                    headers: formatHeaderObj(req.headers)
-                                }, metadata),
-                                response: {}
-                            };
-                        recordedExchanges.push(recordedExchange);
-                        consumeReadableStream(req, passError(handleError, function (result) {
-                            if (result.error) {
-                                // TODO: Consider adding support for recording this (the request erroring out while we're recording it)
-                                return handleError(result.error);
-                            }
-                            recordedExchange.request.body = result.body;
-                            bypassNextConnect = true;
-                            var matchHostHeader = req.headers.host && req.headers.host.match(/^([^:]*)(?::(\d+))?/),
-                                host,
-                                port;
-
-                            // https://github.com/moll/node-mitm/issues/14
-                            if (matchHostHeader) {
-                                if (matchHostHeader[1]) {
-                                    host = matchHostHeader[1];
-                                }
-                                if (matchHostHeader[2]) {
-                                    port = parseInt(matchHostHeader[2], 10);
-                                }
-                            }
-                            if (!host) {
-                                return handleError(new Error('unexpected-mitm recording mode: Could not determine the host name from Host header: ' + req.headers.host));
-                            }
-                            (req.socket.encrypted ? https : http).request(_.extend({
-                                method: req.method,
-                                host: host,
-                                port: port || (req.socket.encrypted ? 443 : 80),
-                                headers: req.headers,
-                                path: req.url
-                            }, metadata)).on('response', function (response) {
-                                recordedExchange.response.statusCode = response.statusCode;
-                                recordedExchange.response.headers = formatHeaderObj(response.headers);
-                                consumeReadableStream(response, passError(handleError, function (result) {
-                                    if (result.error) {
-                                        // TODO: Consider adding support for recording this (the upstream response erroring out while we're recording it)
-                                        return handleError(result.error);
-                                    }
-                                    recordedExchange.response.body = result.body;
-                                    setImmediate(function () {
-                                        res.statusCode = response.statusCode;
-                                        Object.keys(response.headers).forEach(function (headerName) {
-                                            res.setHeader(headerName, response.headers[headerName]);
-                                        });
-                                        res.end(recordedExchange.response.body);
-                                    });
-                                }));
-                            }).on('error', function (err) {
-                                recordedExchange.response = err;
-                                lastHijackedSocket.emit('error', err);
-                            }).end(recordedExchange.request.body);
-                        }));
-                    }));
-
-                    expect.promise(function () {
-                        return expect.shift();
-                    }).caught(handleError).then(function () {
-                        if (!callbackCalled) {
-                            callbackCalled = true;
-                            cleanUp();
-                            recordedExchanges = recordedExchanges.map(trimRecordedExchange);
-                            if (recordedExchanges.length === 1) {
-                                recordedExchanges = recordedExchanges[0];
-                            }
-                            if (injectIntoTest) {
-                                // Find the first call site that has mocha's "test" property:
-                                var containingCallsite = stack.filter(function (parentCallsite) {
-                                    return parentCallsite.receiver.test;
-                                }).shift();
-                                var fileName = containingCallsite && containingCallsite.getFileName();
-                                if (fileName) {
-                                    injectRecordedExchanges(fileName, recordedExchanges, containingCallsite.pos);
-                                }
-                            }
-                            resolve(recordedExchanges);
-                        }
+                        resolve(recordedExchanges);
                     });
                 });
             })


### PR DESCRIPTION
Please take a look at this - it carves out an executeMitm() function from the 'with http recorded' function. Everything else I've got uses this as a base (particularly the tests in the filesystem branch which needs to reuse the separated function).

I think I've still got commit access, but would love a second pair of eyes on this. If you're comfortable with it (my suggestion is to look at a diff ignoring whitespace) I'll push it into the repo as a normal commit. Once in I can go about landing some fixes I've about to have piling up :)

AJB