### PR TITLE
Promisify consumeReadableStream and getMockResponse

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -81,17 +81,6 @@ function trimMessage(message) {
     return message;
 }
 
-function consumeReadableStream(readableStream, cb) {
-    var chunks = [];
-    readableStream.on('data', function (chunk) {
-        chunks.push(chunk);
-    }).on('end', function () {
-        cb(null, { body: Buffer.concat(chunks) });
-    }).on('error', function (err) {
-        cb(null, { body: Buffer.concat(chunks), error: err });
-    });
-}
-
 function trimRecordedExchange(recordedExchange) {
     return {
         request: trimMessage(recordedExchange.request),
@@ -197,39 +186,6 @@ function createMockResponse(responseProperties) {
     mockResponse.protocolVersion = mockResponse.protocolVersion || '1.1';
     mockResponse.statusMessage = mockResponse.statusMessage || http.STATUS_CODES[mockResponse.statusCode];
     return mockResponse;
-}
-
-function getMockResponse(responseProperties, cb) {
-    var mockResponse;
-    var mockResponseError;
-    if (Object.prototype.toString.call(responseProperties) === '[object Error]') {
-        mockResponseError = responseProperties;
-    } else {
-        mockResponse = createMockResponse(responseProperties);
-    }
-
-    if (!mockResponseError && mockResponse && mockResponse.body && typeof mockResponse.body.pipe === 'function') {
-        consumeReadableStream(mockResponse.body, function (err, result) {
-            if (result.error) {
-                mockResponseError = result.error;
-            }
-            if (result.body) {
-                mockResponse.unchunkedBody = result.body;
-            }
-            deliverMockResponse();
-        });
-    } else {
-        setImmediate(deliverMockResponse);
-    }
-
-    function deliverMockResponse() {
-        if (mockResponse && !mockResponseError && (Array.isArray(mockResponse.body) || (mockResponse.body && typeof mockResponse.body === 'object' && (typeof Buffer === 'undefined' || !Buffer.isBuffer(mockResponse.body))))) {
-            if (!mockResponse.headers.has('Content-Type')) {
-                mockResponse.headers.set('Content-Type', 'application/json');
-            }
-        }
-        cb(null, mockResponse, mockResponseError);
-    }
 }
 
 function attachResponseHooks(res, callback) {
@@ -396,6 +352,52 @@ module.exports = {
             }
         }
 
+        function consumeReadableStream(readableStream) {
+            return expect.promise(function (resolve, reject) {
+                var chunks = [];
+                readableStream.on('data', function (chunk) {
+                    chunks.push(chunk);
+                }).on('end', function () {
+                    resolve({ body: Buffer.concat(chunks) });
+                }).on('error', function (err) {
+                    resolve({ body: Buffer.concat(chunks), error: err });
+                });
+            });
+        }
+
+        function getMockResponse(responseProperties, cb) {
+            var mockResponse;
+            var mockResponseError;
+            if (Object.prototype.toString.call(responseProperties) === '[object Error]') {
+                mockResponseError = responseProperties;
+            } else {
+                mockResponse = createMockResponse(responseProperties);
+            }
+
+            if (!mockResponseError && mockResponse && mockResponse.body && typeof mockResponse.body.pipe === 'function') {
+                consumeReadableStream(mockResponse.body).caught(cb).then(function (result) {
+                    if (result.error) {
+                        mockResponseError = result.error;
+                    }
+                    if (result.body) {
+                        mockResponse.unchunkedBody = result.body;
+                    }
+                    deliverMockResponse();
+                });
+            } else {
+                setImmediate(deliverMockResponse);
+            }
+
+            function deliverMockResponse() {
+                if (mockResponse && !mockResponseError && (Array.isArray(mockResponse.body) || (mockResponse.body && typeof mockResponse.body === 'object' && (typeof Buffer === 'undefined' || !Buffer.isBuffer(mockResponse.body))))) {
+                    if (!mockResponse.headers.has('Content-Type')) {
+                        mockResponse.headers.set('Content-Type', 'application/json');
+                    }
+                }
+                cb(null, mockResponse, mockResponseError);
+            }
+        }
+
         function applyInjections() {
             Object.keys(injectionsBySourceFileName).forEach(function (sourceFileName) {
                 var injections = injectionsBySourceFileName[sourceFileName],
@@ -456,7 +458,7 @@ module.exports = {
                             response: {}
                         };
                     recordedExchanges.push(recordedExchange);
-                    consumeReadableStream(req, passError(handleError, function (result) {
+                    return consumeReadableStream(req).caught(handleError).then(function (result) {
                         if (result.error) {
                             // TODO: Consider adding support for recording this (the request erroring out while we're recording it)
                             return handleError(result.error);
@@ -488,7 +490,7 @@ module.exports = {
                         }, metadata)).on('response', function (response) {
                             recordedExchange.response.statusCode = response.statusCode;
                             recordedExchange.response.headers = formatHeaderObj(response.headers);
-                            consumeReadableStream(response, passError(handleError, function (result) {
+                            consumeReadableStream(response).caught(handleError).then(function (result) {
                                 if (result.error) {
                                     // TODO: Consider adding support for recording this (the upstream response erroring out while we're recording it)
                                     return handleError(result.error);
@@ -501,12 +503,12 @@ module.exports = {
                                     });
                                     res.end(recordedExchange.response.body);
                                 });
-                            }));
+                            });
                         }).on('error', function (err) {
                             recordedExchange.response = err;
                             lastHijackedSocket.emit('error', err);
                         }).end(recordedExchange.request.body);
-                    }));
+                    });
                 }));
 
                 expect.promise(function () {
@@ -601,7 +603,7 @@ module.exports = {
 
                         var expectedRequestProperties = resolveExpectedRequestProperties(requestDescription && requestDescription.request);
 
-                        consumeReadableStream(req, passError(handleError, function (result) {
+                        consumeReadableStream(req).caught(handleError).then(function (result) {
                             if (result.error) {
                                 // TODO: Consider adding support for recording this (the request erroring out while we're consuming it)
                                 return handleError(result.error);
@@ -691,7 +693,7 @@ module.exports = {
                             } else {
                                 getMockResponse(responseProperties, passError(handleError, deliverMockResponse));
                             }
-                        }));
+                        });
                     }));
 
                     function handleSuccess() {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -391,7 +391,7 @@ module.exports = {
                         mockResponse.headers.set('Content-Type', 'application/json');
                     }
                 }
-                return { mockResponse: mockResponse, mockResponseError: mockResponseError };
+                return [ mockResponse, mockResponseError ];
             });
         }
 
@@ -688,9 +688,7 @@ module.exports = {
                                     deliverMockResponse(null, err);
                                 });
                             } else {
-                                getMockResponse(responseProperties).caught(handleError).then(function (mockResponseAndError) {
-                                    deliverMockResponse(mockResponseAndError.mockResponse, mockResponseAndError.mockResponseError);
-                                });
+                                getMockResponse(responseProperties).caught(handleError).spread(deliverMockResponse);
                             }
                         });
                     }));
@@ -719,10 +717,10 @@ module.exports = {
 
                                  expectedRequestProperties = resolveExpectedRequestProperties(expectedRequestProperties);
 
-                                 getMockResponse(responseProperties).caught(cb).then(function (mockResponseAndError) {
+                                 getMockResponse(responseProperties).caught(cb).spread(function (mockResponse, mockResponseError) {
                                      httpConversationSatisfySpec.exchanges.push({
                                          request: expectedRequestProperties,
-                                         response: mockResponseAndError.mockResponseError || mockResponseAndError.mockResponse
+                                         response: mockResponseError || mockResponse
                                      });
                                      cb();
                                  });

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -365,7 +365,7 @@ module.exports = {
             });
         }
 
-        function getMockResponse(responseProperties, cb) {
+        function getMockResponse(responseProperties) {
             var mockResponse;
             var mockResponseError;
             if (Object.prototype.toString.call(responseProperties) === '[object Error]') {
@@ -374,28 +374,25 @@ module.exports = {
                 mockResponse = createMockResponse(responseProperties);
             }
 
-            if (!mockResponseError && mockResponse && mockResponse.body && typeof mockResponse.body.pipe === 'function') {
-                consumeReadableStream(mockResponse.body).caught(cb).then(function (result) {
-                    if (result.error) {
-                        mockResponseError = result.error;
-                    }
-                    if (result.body) {
-                        mockResponse.unchunkedBody = result.body;
-                    }
-                    deliverMockResponse();
-                });
-            } else {
-                setImmediate(deliverMockResponse);
-            }
-
-            function deliverMockResponse() {
+            return expect.promise(function () {
+                if (!mockResponseError && mockResponse && mockResponse.body && typeof mockResponse.body.pipe === 'function') {
+                    return consumeReadableStream(mockResponse.body).then(function (result) {
+                        if (result.error) {
+                            mockResponseError = result.error;
+                        }
+                        if (result.body) {
+                            mockResponse.unchunkedBody = result.body;
+                        }
+                    });
+                }
+            }).then(function () {
                 if (mockResponse && !mockResponseError && (Array.isArray(mockResponse.body) || (mockResponse.body && typeof mockResponse.body === 'object' && (typeof Buffer === 'undefined' || !Buffer.isBuffer(mockResponse.body))))) {
                     if (!mockResponse.headers.has('Content-Type')) {
                         mockResponse.headers.set('Content-Type', 'application/json');
                     }
                 }
-                cb(null, mockResponse, mockResponseError);
-            }
+                return { mockResponse: mockResponse, mockResponseError: mockResponseError };
+            });
         }
 
         function applyInjections() {
@@ -691,7 +688,9 @@ module.exports = {
                                     deliverMockResponse(null, err);
                                 });
                             } else {
-                                getMockResponse(responseProperties, passError(handleError, deliverMockResponse));
+                                getMockResponse(responseProperties).caught(handleError).then(function (mockResponseAndError) {
+                                    deliverMockResponse(mockResponseAndError.mockResponse, mockResponseAndError.mockResponseError);
+                                });
                             }
                         });
                     }));
@@ -720,12 +719,11 @@ module.exports = {
 
                                  expectedRequestProperties = resolveExpectedRequestProperties(expectedRequestProperties);
 
-                                 getMockResponse(responseProperties, function (mockResponse, mockResponseError) {
+                                 getMockResponse(responseProperties).caught(cb).then(function (mockResponseAndError) {
                                      httpConversationSatisfySpec.exchanges.push({
                                          request: expectedRequestProperties,
-                                         response: mockResponseError || mockResponse
+                                         response: mockResponseAndError.mockResponseError || mockResponseAndError.mockResponse
                                      });
-
                                      cb();
                                  });
                              }, handleSuccess);


### PR DESCRIPTION
This is just one step of the way there. We need to figure out how to promisify their surroundings as well, including the whole `createSerializedRequestHandler` thing.

Also, this makes me want to try changing `messy.HttpResponse` so it can contain the `mockResponseError` as a property, even if there is no response.