### PR TITLE
Add test for request streaming and basic request properties resolutio…

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -789,14 +789,20 @@ module.exports = {
                             (function nextItem() {
                                 var remainingDescription = requestDescriptions.shift();
                                 if (remainingDescription) {
-                                    return getMockResponse(remainingDescription.response).spread(function (mockResponse, mockResponseError) {
+                                    var expectedRequestProperties;
+
+                                    return expect.promise(function () {
+                                        expectedRequestProperties = resolveExpectedRequestProperties(remainingDescription.request);
+                                    }).then(function () {
+                                        return getMockResponse(remainingDescription.response);
+                                    }).spread(function (mockResponse, mockResponseError) {
                                         httpConversationSatisfySpec.exchanges.push({
-                                            request: resolveExpectedRequestProperties(remainingDescription.request),
+                                            request: expectedRequestProperties,
                                             response: mockResponseError || mockResponse
                                         });
 
                                         return nextItem();
-                                    });
+                                    }).caught(reject);
                                 } else {
                                     resolve([httpConversation, httpConversationSatisfySpec]);
                                 }

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -174,6 +174,10 @@ function resolveExpectedRequestProperties(expectedRequestProperties) {
 
     var expectedRequestBody = expectedRequestProperties.body;
     if (Array.isArray(expectedRequestBody) || (expectedRequestBody && typeof expectedRequestBody === 'object' && !isRegExp(expectedRequestBody) && (typeof Buffer === 'undefined' || !Buffer.isBuffer(expectedRequestBody)))) {
+        // in the case of a streamed request body and skip asserting the body
+        if (typeof expectedRequestBody.pipe === 'function') {
+            throw new Error('unexpected-mitm: a stream cannot be used to verify the request body, please specify the buffer instead.');
+        }
         expectedRequestProperties.headers = expectedRequestProperties.headers || {};
         if (Object.keys(expectedRequestProperties.headers).every(function (key) {
             return key.toLowerCase() !== 'content-type';
@@ -642,14 +646,17 @@ module.exports = {
                                     _.pick(lastHijackedSocketOptions && lastHijackedSocketOptions.agent && lastHijackedSocketOptions.agent.options, messy.HttpRequest.metadataPropertyNames)
                                 ),
                             requestDescription = currentDescription,
-                            responseProperties = requestDescription && requestDescription.response;
+                            responseProperties = requestDescription && requestDescription.response,
+                            expectedRequestProperties;
 
-                        var expectedRequestProperties = resolveExpectedRequestProperties(requestDescription && requestDescription.request);
-
-                        consumeReadableStream(req, {skipConcat: true}).caught(reject).then(function (result) {
+                        expect.promise(function () {
+                            expectedRequestProperties = resolveExpectedRequestProperties(requestDescription && requestDescription.request);
+                        }).then(function () {
+                            return consumeReadableStream(req, {skipConcat: true});
+                        }).then(function (result) {
                             if (result.error) {
                                 // TODO: Consider adding support for recording this (the request erroring out while we're consuming it)
-                                return reject(result.error);
+                                throw result.error;
                             }
                             var requestProperties = _.extend({
                                 method: req.method,
@@ -750,8 +757,18 @@ module.exports = {
                                     deliverMockResponse(null, err);
                                 });
                             } else {
-                                getMockResponse(responseProperties).caught(reject).spread(deliverMockResponse);
+                                getMockResponse(responseProperties).spread(deliverMockResponse);
                             }
+                        }).caught(function (e) {
+                            /*
+                             * This error handling path is triggered for any
+                             * error occuring before a response is generated.
+                             * In those circumstances, the deferred assertion
+                             * will still be pending and must be completed. We
+                             * do this by signalling the error on the socket.
+                             */
+                            lastHijackedSocket.emit('error', e);
+                            reject(e);
                         });
                     }));
 

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -536,6 +536,23 @@ describe('unexpectedMitm', function () {
         });
     });
 
+    it('should error if the request body provided for verification was a stream', function () {
+        return expect(
+            expect('http://www.google.com/', 'with http mocked out', {
+                request: {
+                    url: 'GET /',
+                    body: fs.createReadStream(pathModule.resolve(__dirname, '..', 'testdata', 'foo.txt'))
+                },
+                response: 200
+            }, 'to yield response', {
+                statusCode: 200
+            }),
+            'when rejected',
+            'to have message',
+            'unexpected-mitm: a stream cannot be used to verify the request body, please specify the buffer instead.'
+        );
+    });
+
     describe('with the expected request body given as an object (shorthand for JSON)', function () {
         it('should succeed the match', function () {
             return expect({

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -726,6 +726,34 @@ describe('unexpectedMitm', function () {
         );
     });
 
+    it('should produce an error if a mocked request is not exercised with an expected request stream', function () {
+        var requestBodyStream = new stream.Readable();
+        requestBodyStream._read = function (num, cb) {
+            requestBodyStream._read = function () {};
+            setImmediate(function () {
+                requestBodyStream.push('foobarquux');
+                requestBodyStream.push(null);
+            });
+        };
+        return expect(
+            expect('http://www.google.com/foo', 'with http mocked out', [
+                {
+                    request: 'GET /foo',
+                    response: 200
+                },
+                {
+                    request: {
+                        body: requestBodyStream
+                    },
+                    response: 200
+                }
+            ], 'to yield response', 200),
+            'when rejected',
+            'to have message',
+            'unexpected-mitm: a stream cannot be used to verify the request body, please specify the buffer instead.'
+        );
+    });
+
     it('should produce an error if a mocked request is not exercised and there are non-trivial assertions on it', function () {
         return expect(
             expect('http://www.google.com/foo', 'with http mocked out', [


### PR DESCRIPTION
…n fix.

To avoid comparing a decoded request body to it's original Readable stream
source check for the case of a stream and exclude the body from assertion.

This gets coverage to around 90% across the board.