### PR TITLE
Mock verification

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -868,6 +868,59 @@ module.exports = {
                 }).finally(function () {
                     mitm.disable();
                 });
+            })
+            .addAssertion('<any> with http mocked out and verified <array|object> <assertion>', function (expect, subject, requestDescriptions) {
+                expect.errorMode = 'default';
+
+                expect.args.splice(1, 0, 'with http mocked out with extra info');
+                expect.args.splice(2, 0, requestDescriptions);
+
+                return expect.promise(function () {
+                    return expect.shift(subject);
+                }).spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
+                    var httpExchanges = httpConversation.exchanges.slice(0);
+                    var httpVerificationSatisfySpec = {
+                        exchanges: []
+                    };
+
+                    return (function nextItem() {
+                        var exchange = httpExchanges.shift();
+                        var request;
+
+                        if (exchange) {
+                            request = exchange.request;
+
+                            return performRequest({
+                                encrypted: request.encrypted,
+                                headers: request.headers.toJSON(),
+                                method: request.method,
+                                host: request.host,
+                                port: request.port,
+                                path: request.url,
+                                body: request.body
+                            }).then(function (responseResult) {
+                                // remove an empty body from the comparison
+                                if (responseResult.body.length === 0) {
+                                    responseResult = _.omit(responseResult, 'body');
+                                }
+
+                                httpVerificationSatisfySpec.exchanges.push({
+                                    request: {},
+                                    response: responseResult
+                                });
+
+                                return nextItem();
+                            });
+                        } else {
+                            return httpVerificationSatisfySpec;
+                        }
+                    })().then(function () {
+                        return expect(httpConversation, 'to satisfy', httpVerificationSatisfySpec);
+                    }).then(function () {
+                        // always resolve "with http mocked out" with exchanges
+                        return [ fulfilmentValue, httpConversation, httpConversationSatisfySpec ];
+                    });
+                });
             });
     }
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -647,18 +647,18 @@ module.exports = {
                 expect.errorMode = 'nested';
                 var mitm = createMitm();
 
-                return expect.promise(function (resolve, reject) {
-                    if (!Array.isArray(requestDescriptions)) {
-                        if (typeof requestDescriptions === 'undefined') {
-                            requestDescriptions = [];
-                        } else {
-                            requestDescriptions = [requestDescriptions];
-                        }
+                if (!Array.isArray(requestDescriptions)) {
+                    if (typeof requestDescriptions === 'undefined') {
+                        requestDescriptions = [];
                     } else {
-                        // duplicate descriptions to allow array consumption
-                        requestDescriptions = requestDescriptions.slice(0);
+                        requestDescriptions = [requestDescriptions];
                     }
+                } else {
+                    // duplicate descriptions to allow array consumption
+                    requestDescriptions = requestDescriptions.slice(0);
+                }
 
+                return expect.promise(function (resolve, reject) {
                     var httpConversation = new messy.HttpConversation(),
                         httpConversationSatisfySpec = {exchanges: []},
                         lastHijackedSocket,

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -522,6 +522,66 @@ module.exports = {
             });
         }
 
+        function createVerifier(expect, verifyOptions) {
+            return function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
+                var httpExchanges = httpConversation.exchanges.slice(0);
+                var httpVerificationSatisfySpec = {
+                    exchanges: []
+                };
+
+                function nextItem() {
+                    var exchange = httpExchanges.shift();
+                    var request;
+
+                    if (exchange) {
+                        request = exchange.request;
+
+                        return performRequest({
+                            encrypted: request.encrypted,
+                            headers: request.headers.toJSON(),
+                            method: request.method,
+                            host: request.host,
+                            port: request.port,
+                            path: request.url,
+                            body: request.body
+                        }).then(function (responseResult) {
+                            // remove an empty body from the comparison
+                            if (responseResult.body.length === 0) {
+                                responseResult = _.omit(responseResult, 'body');
+                            }
+
+                            httpVerificationSatisfySpec.exchanges.push({
+                                request: {},
+                                response: responseByValidationRules(responseResult, verifyOptions.response)
+                            });
+
+                            return nextItem();
+                        });
+                    } else {
+                        return httpVerificationSatisfySpec;
+                    }
+                }
+
+                return expect.promise(function (resolve, reject) {
+                    resolve(nextItem());
+                }).then(function (httpVerificationSatisfySpec) {
+                    expect.withError(function () {
+                        return expect(httpConversation, 'to satisfy', httpVerificationSatisfySpec);
+                    }, function (e) {
+                        expect.errorMode = 'bubble';
+                        expect.fail({
+                            diff: function (output) {
+                                return output.text('The mock and service have diverged.\n\n').append(e.getErrorMessage(output));
+                            }
+                        });
+                    });
+                }).then(function () {
+                    // always resolve "with http mocked out" with exchanges
+                    return [ fulfilmentValue, httpConversation, httpConversationSatisfySpec ];
+                });
+            };
+        }
+
         function executeMitm(expect, subject) {
             var mitm = createMitm(),
                 recordedExchanges = [];
@@ -643,7 +703,7 @@ module.exports = {
                     return recordedExchanges;
                 });
             })
-            .addAssertion('<any> with http mocked out [with extra info] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
+            .addAssertion('<any> with http mocked out [with extra info] [and verified] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
                 expect.errorMode = 'nested';
                 var mitm = createMitm();
 
@@ -658,7 +718,13 @@ module.exports = {
                     requestDescriptions = requestDescriptions.slice(0);
                 }
 
-                return expect.promise(function (resolve, reject) {
+                var verifyOptions = {};
+                if (requestDescriptions[0]) {
+                    verifyOptions = requestDescriptions[0].verify || {};
+                    delete requestDescriptions[0].verify;
+                }
+
+                var assertionPromise = expect.promise(function (resolve, reject) {
                     var httpConversation = new messy.HttpConversation(),
                         httpConversationSatisfySpec = {exchanges: []},
                         lastHijackedSocket,
@@ -873,7 +939,7 @@ module.exports = {
                 }).spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
                     expect.errorMode = 'default';
                     return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
-                        if (expect.flags['with extra info']) {
+                        if (expect.flags['and verified'] || expect.flags['with extra info']) {
                             return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
                         } else {
                             return fulfilmentValue;
@@ -882,75 +948,14 @@ module.exports = {
                 }).finally(function () {
                     mitm.disable();
                 });
-            })
-            .addAssertion('<any> with http mocked out and verified <array|object> <assertion>', function (expect, subject, requestDescriptions) {
-                expect.errorMode = 'default';
 
-                expect.args.splice(1, 0, 'with http mocked out with extra info');
-                expect.args.splice(2, 0, requestDescriptions);
+                if (expect.flags['and verified']) {
+                    expect.errorMode = 'default';
 
-                var verifyBlock = requestDescriptions.verify || {};
-                delete requestDescriptions.verify;
+                    return assertionPromise.spread(createVerifier(expect, verifyOptions));
+                }
 
-                return expect.promise(function () {
-                    return expect.shift(subject);
-                }).spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
-                    var httpExchanges = httpConversation.exchanges.slice(0);
-                    var httpVerificationSatisfySpec = {
-                        exchanges: []
-                    };
-
-                    function nextItem() {
-                        var exchange = httpExchanges.shift();
-                        var request;
-
-                        if (exchange) {
-                            request = exchange.request;
-
-                            return performRequest({
-                                encrypted: request.encrypted,
-                                headers: request.headers.toJSON(),
-                                method: request.method,
-                                host: request.host,
-                                port: request.port,
-                                path: request.url,
-                                body: request.body
-                            }).then(function (responseResult) {
-                                // remove an empty body from the comparison
-                                if (responseResult.body.length === 0) {
-                                    responseResult = _.omit(responseResult, 'body');
-                                }
-
-                                httpVerificationSatisfySpec.exchanges.push({
-                                    request: {},
-                                    response: responseByValidationRules(responseResult, verifyBlock.response)
-                                });
-
-                                return nextItem();
-                            });
-                        } else {
-                            return httpVerificationSatisfySpec;
-                        }
-                    }
-
-                    return expect.promise(function (resolve, reject) {
-                        resolve(nextItem());
-                    }).then(function (httpVerificationSatisfySpec) {
-                        expect.withError(function () {
-                            return expect(httpConversation, 'to satisfy', httpVerificationSatisfySpec);
-                        }, function (e) {
-                            expect.errorMode = 'bubble';
-                            expect.fail({
-                                diff: function (output) {
-                                    return output.text('The mock and service have diverged.\n\n').append(e.getErrorMessage(output));
-                                }
-                            });
-                        });
-                    }).then(function () {
-                        // always resolve "with http mocked out" with exchanges
-                        return [ fulfilmentValue, httpConversation, httpConversationSatisfySpec ];
-                    });
-                });
+                return assertionPromise;
             });
     }
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -522,7 +522,7 @@ module.exports = {
             });
         }
 
-        function createVerifier(expect, verifyOptions) {
+        function createVerifier(expect, verifyBlocks) {
             return function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
                 var httpExchanges = httpConversation.exchanges.slice(0);
                 var httpVerificationSatisfySpec = {
@@ -531,6 +531,7 @@ module.exports = {
 
                 function nextItem() {
                     var exchange = httpExchanges.shift();
+                    var verifyOptions = verifyBlocks.shift();
                     var request;
 
                     if (exchange) {
@@ -718,11 +719,11 @@ module.exports = {
                     requestDescriptions = requestDescriptions.slice(0);
                 }
 
-                var verifyOptions = {};
-                if (requestDescriptions[0]) {
-                    verifyOptions = requestDescriptions[0].verify || {};
-                    delete requestDescriptions[0].verify;
-                }
+                var verifyBlocks = requestDescriptions.map(function (description) {
+                    var verifyBlock = description.verify || {};
+                    delete description.verify;
+                    return verifyBlock;
+                });
 
                 var assertionPromise = expect.promise(function (resolve, reject) {
                     var httpConversation = new messy.HttpConversation(),
@@ -952,7 +953,7 @@ module.exports = {
                 if (expect.flags['and verified']) {
                     expect.errorMode = 'default';
 
-                    return assertionPromise.spread(createVerifier(expect, verifyOptions));
+                    return assertionPromise.spread(createVerifier(expect, verifyBlocks));
                 }
 
                 return assertionPromise;

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -883,7 +883,7 @@ module.exports = {
                         exchanges: []
                     };
 
-                    return (function nextItem() {
+                    function nextItem() {
                         var exchange = httpExchanges.shift();
                         var request;
 
@@ -914,8 +914,21 @@ module.exports = {
                         } else {
                             return httpVerificationSatisfySpec;
                         }
-                    })().then(function () {
-                        return expect(httpConversation, 'to satisfy', httpVerificationSatisfySpec);
+                    }
+
+                    return expect.promise(function (resolve, reject) {
+                        resolve(nextItem());
+                    }).then(function (httpVerificationSatisfySpec) {
+                        expect.withError(function () {
+                            return expect(httpConversation, 'to satisfy', httpVerificationSatisfySpec);
+                        }, function (e) {
+                            expect.errorMode = 'bubble';
+                            expect.fail({
+                                diff: function (output) {
+                                    return output.text('The mock and service have diverged.\n\n').append(e.getErrorMessage(output));
+                                }
+                            });
+                        });
                     }).then(function () {
                         // always resolve "with http mocked out" with exchanges
                         return [ fulfilmentValue, httpConversation, httpConversationSatisfySpec ];

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -313,15 +313,18 @@ function determineInjectionCallsite(stack) {
     }
 }
 
-function responseByValidationRules(response, validationBlock) {
-    if (!validationBlock) {
-        return response;
+function responseForVerification(response, validationBlock) {
+    // remove an empty body from the comparison
+    if (response.body.length === 0) {
+        delete response.body;
     }
 
-    if (validationBlock.ignoreHeaders) {
-        validationBlock.ignoreHeaders.forEach(function (headerKey) {
-            delete response.headers[headerKey.toLowerCase()];
-        });
+    if (validationBlock) {
+        if (validationBlock.ignoreHeaders) {
+            validationBlock.ignoreHeaders.forEach(function (headerKey) {
+                delete response.headers[headerKey.toLowerCase()];
+            });
+        }
     }
 
     return response;
@@ -546,14 +549,9 @@ module.exports = {
                             path: request.url,
                             body: request.body
                         }).then(function (responseResult) {
-                            // remove an empty body from the comparison
-                            if (responseResult.body.length === 0) {
-                                responseResult = _.omit(responseResult, 'body');
-                            }
-
                             httpVerificationSatisfySpec.exchanges.push({
                                 request: {},
-                                response: responseByValidationRules(responseResult, verifyOptions.response)
+                                response: responseForVerification(responseResult, verifyOptions.response)
                             });
 
                             return nextItem();

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -314,15 +314,27 @@ function determineInjectionCallsite(stack) {
 }
 
 function responseForVerification(response, validationBlock) {
-    // remove an empty body from the comparison
+    // arrange to use formatted headers
+    response.headers = formatHeaderObj(response.headers);
+
+    // remove the content length from the comparison
+    delete response.headers['Content-Length'];
+
+    // call messy for decoding of text values
+    var messyMessage = new messy.Message({headers: {'Content-Type': response.headers['Content-Type']}, unchunkedBody: response.body});
+
     if (response.body.length === 0) {
+        // remove an empty body from the comparison
         delete response.body;
+    } else if (messyMessage.hasTextualContentType) {
+        // read a messy decoded version of the body
+        response.body = messyMessage.body;
     }
 
     if (validationBlock) {
         if (validationBlock.ignoreHeaders) {
             validationBlock.ignoreHeaders.forEach(function (headerKey) {
-                delete response.headers[headerKey.toLowerCase()];
+                delete response.headers[messy.formatHeaderName(headerKey)];
             });
         }
     }

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -590,9 +590,6 @@ module.exports = {
                             }
                         });
                     });
-                }).then(function () {
-                    // always resolve "with http mocked out" with exchanges
-                    return [ fulfilmentValue, httpConversation, httpConversationSatisfySpec ];
                 });
             };
         }
@@ -718,7 +715,7 @@ module.exports = {
                     return recordedExchanges;
                 });
             })
-            .addAssertion('<any> with http mocked out [with extra info] [and verified] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
+            .addAssertion('<any> with http mocked out [and verified] [with extra info] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
                 expect.errorMode = 'nested';
                 var mitm = createMitm();
 
@@ -967,7 +964,17 @@ module.exports = {
                 if (expect.flags['and verified']) {
                     expect.errorMode = 'default';
 
-                    return assertionPromise.spread(createVerifier(expect, verifyBlocks));
+                    var verifier = createVerifier(expect, verifyBlocks);
+
+                    return assertionPromise.spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
+                        return verifier(fulfilmentValue, httpConversation, httpConversationSatisfySpec).then(function () {
+                            if (expect.flags['with extra info']) {
+                                return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
+                            } else {
+                                return fulfilmentValue;
+                            }
+                        });
+                    });
                 }
 
                 return assertionPromise;

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -313,6 +313,20 @@ function determineInjectionCallsite(stack) {
     }
 }
 
+function responseByValidationRules(response, validationBlock) {
+    if (!validationBlock) {
+        return response;
+    }
+
+    if (validationBlock.ignoreHeaders) {
+        validationBlock.ignoreHeaders.forEach(function (headerKey) {
+            delete response.headers[headerKey.toLowerCase()];
+        });
+    }
+
+    return response;
+}
+
 
 module.exports = {
     name: 'unexpected-mitm',
@@ -875,6 +889,9 @@ module.exports = {
                 expect.args.splice(1, 0, 'with http mocked out with extra info');
                 expect.args.splice(2, 0, requestDescriptions);
 
+                var verifyBlock = requestDescriptions.verify || {};
+                delete requestDescriptions.verify;
+
                 return expect.promise(function () {
                     return expect.shift(subject);
                 }).spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
@@ -906,7 +923,7 @@ module.exports = {
 
                                 httpVerificationSatisfySpec.exchanges.push({
                                     request: {},
-                                    response: responseResult
+                                    response: responseByValidationRules(responseResult, verifyBlock.response)
                                 });
 
                                 return nextItem();

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -57,6 +57,13 @@ function lineNumberToIndex(string, lineNumber) {
     return startOfLineIndex;
 }
 
+function trimHeaders(message) {
+    delete message.headers['Content-Length'];
+    delete message.headers['Transfer-Encoding'];
+    delete message.headers.Connection;
+    delete message.headers.Date;
+}
+
 function trimMessage(message) {
     if (typeof message.body !== 'undefined') {
         if (message.body.length === 0) {
@@ -77,10 +84,7 @@ function trimMessage(message) {
         delete message.statusCode;
     }
     if (message.headers) {
-        delete message.headers['Content-Length'];
-        delete message.headers['Transfer-Encoding'];
-        delete message.headers.Connection;
-        delete message.headers.Date;
+        trimHeaders(message);
         if (Object.keys(message.headers).length === 0) {
             delete message.headers;
         }
@@ -317,8 +321,8 @@ function responseForVerification(response, validationBlock) {
     // arrange to use formatted headers
     response.headers = formatHeaderObj(response.headers);
 
-    // remove the content length from the comparison
-    delete response.headers['Content-Length'];
+    // remove superfluous headers from the response
+    trimHeaders(response);
 
     // call messy for decoding of text values
     var messyMessage = new messy.Message({headers: {'Content-Type': response.headers['Content-Type']}, unchunkedBody: response.body});

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1644,10 +1644,10 @@ describe('unexpectedMitm', function () {
                         '\n' +
                         'The mock and service have diverged.\n' +
                         '\n' +
-                        "expected { url: 'GET http://localhost:59891/' } with http mocked out and verified { response: 405 } to yield response 405\n" +
+                        "expected { url: 'GET " + serverUrl + "' } with http mocked out and verified { response: 405 } to yield response 405\n" +
                         '\n' +
                         'GET / HTTP/1.1\n' +
-                        'Host: localhost:59891\n' +
+                        'Host: ' + serverHostname + ':59891\n' +
                         '\n' +
                         'HTTP/1.1 405 Method Not Allowed // should be 406 Not Acceptable\n' +
                         '                                //\n' +

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1559,6 +1559,28 @@ describe('unexpectedMitm', function () {
             );
         });
 
+        it('should allow excluding headers from verification', function () {
+            handleRequest = function (req, res) {
+                res.statusCode = 405;
+                res.setHeader('X-Is-Test', 'yes');
+                res.end();
+            };
+
+            return expect(
+                expect({
+                    url: 'GET ' + serverUrl
+                }, 'with http mocked out and verified', {
+                    response: 405,
+                    verify: {
+                        response: {
+                            ignoreHeaders: ['x-is-test']
+                        }
+                    }
+                }, 'to yield response', 405),
+                'to be fulfilled'
+            );
+        });
+
         it('should fail with a diff', function () {
             handleRequest = function (req, res) {
                 res.statusCode = 406;

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1516,4 +1516,47 @@ describe('unexpectedMitm', function () {
             expect(value, 'to equal', 2);
         });
     });
+
+    describe('when verifying', function () {
+        var handleRequest,
+            server,
+            serverAddress,
+            serverHostname,
+            serverUrl;
+        beforeEach(function () {
+            handleRequest = undefined;
+            server = http.createServer(function (req, res) {
+                res.sendDate = false;
+                handleRequest(req, res);
+            }).listen(0);
+            serverAddress = server.address();
+            serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address;
+            serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/';
+        });
+
+        afterEach(function () {
+            server.close();
+        });
+
+        it('should verify and resolve with the exchanges', function () {
+            handleRequest = function (req, res) {
+                res.statusCode = 405;
+                res.end();
+            };
+
+            return expect(
+                expect({
+                    url: 'GET ' + serverUrl
+                }, 'with http mocked out and verified', {
+                    response: 405
+                }, 'to yield response', 405),
+                'when fulfilled',
+                'to satisfy', [
+                    expect.it('to be an object'),
+                    new messy.HttpExchange(),
+                    expect.it('to be an object')
+                ]
+            );
+        });
+    });
 });

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1526,7 +1526,6 @@ describe('unexpectedMitm', function () {
         beforeEach(function () {
             handleRequest = undefined;
             server = http.createServer(function (req, res) {
-                res.sendDate = false;
                 handleRequest(req, res);
             }).listen(59891);
             serverAddress = server.address();

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1528,7 +1528,7 @@ describe('unexpectedMitm', function () {
             server = http.createServer(function (req, res) {
                 res.sendDate = false;
                 handleRequest(req, res);
-            }).listen(0);
+            }).listen(59891);
             serverAddress = server.address();
             serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address;
             serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/';
@@ -1557,6 +1557,39 @@ describe('unexpectedMitm', function () {
                     expect.it('to be an object')
                 ]
             );
+        });
+
+        it('should fail with a diff', function () {
+            handleRequest = function (req, res) {
+                res.statusCode = 406;
+                res.end();
+            };
+
+            return expect(
+                expect({
+                    url: 'GET ' + serverUrl
+                }, 'with http mocked out and verified', {
+                    response: 405
+                }, 'to yield response', 405),
+                'when rejected',
+                'to have message',
+                function (message) {
+                    expect(trimDiff(message), 'to equal',
+                        'Explicit failure\n' +
+                        '\n' +
+                        'The mock and service have diverged.\n' +
+                        '\n' +
+                        "expected { url: 'GET http://localhost:59891/' } with http mocked out and verified { response: 405 } to yield response 405\n" +
+                        '\n' +
+                        'GET / HTTP/1.1\n' +
+                        'Host: localhost:59891\n' +
+                        '\n' +
+                        'HTTP/1.1 405 Method Not Allowed // should be 406 Not Acceptable\n' +
+                        '                                //\n' +
+                        '                                // -HTTP/1.1 405 Method Not Allowed\n' +
+                        '                                // +HTTP/1.1 406 Not Acceptable\n'
+                    );
+                });
         });
     });
 });

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1580,6 +1580,36 @@ describe('unexpectedMitm', function () {
             );
         });
 
+        it('should verify an object', function () {
+            handleRequest = function (req, res) {
+                res.statusCode = 201;
+                res.setHeader('Content-Type', 'application/json');
+                res.end(new Buffer(JSON.stringify({foo:'bar'})));
+            };
+
+            return expect(
+                expect({
+                    url: 'GET ' + serverUrl
+                }, 'with http mocked out and verified', {
+                    response: {
+                        statusCode: 201,
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: {
+                            foo: 'bar'
+                        }
+                    }
+                }, 'to yield response', {
+                    statusCode: 201,
+                    body: {
+                        foo: 'bar'
+                    }
+                }),
+                'to be fulfilled'
+            );
+        });
+
         it('should allow excluding headers from verification', function () {
             handleRequest = function (req, res) {
                 res.statusCode = 405;

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1559,6 +1559,28 @@ describe('unexpectedMitm', function () {
             );
         });
 
+        it('should verify an ISO-8859-1 request', function () {
+            handleRequest = function (req, res) {
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/html; charset=ISO-8859-1');
+                res.end(new Buffer([0x62, 0x6c, 0xe5, 0x62, 0xe6, 0x72, 0x67, 0x72, 0xf8, 0x64]));
+            };
+
+            return expect(
+                expect({
+                    url: 'GET ' + serverUrl
+                }, 'with http mocked out and verified', {
+                    response: {
+                        headers: {
+                            'Content-Type': 'text/html; charset=ISO-8859-1'
+                        },
+                        body: new Buffer([0x62, 0x6c, 0xe5, 0x62, 0xe6, 0x72, 0x67, 0x72, 0xf8, 0x64])
+                    }
+                }, 'to yield response', 200),
+                'to be fulfilled'
+            );
+        });
+
         it('should allow excluding headers from verification', function () {
             handleRequest = function (req, res) {
                 res.statusCode = 405;

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1537,7 +1537,7 @@ describe('unexpectedMitm', function () {
             server.close();
         });
 
-        it('should verify and resolve with the exchanges', function () {
+        it('should verify and resolve with delegated fulfilment', function () {
             handleRequest = function (req, res) {
                 res.statusCode = 405;
                 res.end();
@@ -1550,7 +1550,26 @@ describe('unexpectedMitm', function () {
                     response: 405
                 }, 'to yield response', 405),
                 'when fulfilled',
-                'to satisfy', [
+                'to satisfy',
+                expect.it('to be an object')
+            );
+        });
+
+        it('should verify and resolve with extra info', function () {
+            handleRequest = function (req, res) {
+                res.statusCode = 405;
+                res.end();
+            };
+
+            return expect(
+                expect({
+                    url: 'GET ' + serverUrl
+                }, 'with http mocked out and verified with extra info', {
+                    response: 405
+                }, 'to yield response', 405),
+                'when fulfilled',
+                'to satisfy',
+                [
                     expect.it('to be an object'),
                     new messy.HttpExchange(),
                     expect.it('to be an object')


### PR DESCRIPTION
This branch adds an extra "and verified" flag to "with http mocked out" allowing it to check for differences between the declarative mock and the real service.

While there is another goal not expressed in the current commits (a command line option which causes verification without using the flag), this branch is functionally complete and I'd like to get a review of the approach. To focus that review, I think what follows are the potentially most contentious points:
* the verifier is optionally tied to the promise based on seeing the "and verified" flag
* the user of a separate verify block alongside request/response

On that last point - I still feel it is better to separate options to -mitm from request/response blocks so they contain only what is sent. I also see we may grow other options, or may want to have one list of headers to ignore across both request/response which would be helped by such a design.