### PR TITLE
with http recorded and injected: Support injecting into a compound assertion

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -422,7 +422,7 @@ module.exports = {
             if (detectedIndent) {
                 indentationWidth = detectedIndent.amount;
             }
-            var searchRegExp = /([ ]*)(.*)(['"])with http recorded and injected\3,/g;
+            var searchRegExp = /([ ]*)(.*)(['"])with http recorded and injected(\3,| )/g;
             /*
              * Ensure the search for the for the assertion string occurs from
              * the line number of the callsite until it is found. Since we can
@@ -435,12 +435,13 @@ module.exports = {
             if (matchSearchRegExp) {
                 var lineIndentation = matchSearchRegExp[1],
                     before = matchSearchRegExp[2],
-                    quote = matchSearchRegExp[3];
+                    quote = matchSearchRegExp[3],
+                    after = matchSearchRegExp[4];
 
                 (injectionsBySourceFileName[sourceFileName] = injectionsBySourceFileName[sourceFileName] || []).push({
                     pos: matchSearchRegExp.index,
                     length: matchSearchRegExp[0].length,
-                    replacement: lineIndentation + before + quote + 'with http mocked out' + quote + ', ' + stringify(recordedExchanges, indentationWidth).replace(/\n^/mg, '\n' + lineIndentation) + ','
+                    replacement: lineIndentation + before + quote + 'with http mocked out' + quote + ', ' + stringify(recordedExchanges, indentationWidth).replace(/\n^/mg, '\n' + lineIndentation) + (after === ' ' ? ', ' + quote : ',')
                 });
             } else {
                 console.warn('unexpected-mitm: Could not find the right place to inject the recorded exchanges into ' + sourceFileName + ' (around line ' + sourceLineNumber + '): ' + stringify(recordedExchanges, indentationWidth, expect));

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1408,6 +1408,10 @@ describe('unexpectedMitm', function () {
             return expect('utf8file', 'when injected becomes', isNodeZeroTen ? 'utf8file-injected-v0_10' : 'utf8file-injected');
         });
 
+        it('should record and inject into a compound assertion', function () {
+            return expect('compound', 'when injected becomes', isNodeZeroTen ? 'compound-injected-v0_10' : 'compound-injected');
+        });
+
         it('should correctly handle buffer injections', function () {
             return expect('bufferfile', 'when injected becomes', isNodeZeroTen ? 'bufferfile-injected-v0_10' : 'bufferfile-injected');
         });

--- a/testdata/compound-injected-v0_10.js
+++ b/testdata/compound-injected-v0_10.js
@@ -1,0 +1,45 @@
+/*global describe, it, beforeEach, afterEach*/
+var http = require('http');
+var expect = require('unexpected');
+
+describe('example with http recorded and injected file', function () {
+    expect = expect.clone()
+        .use(require('../lib/unexpectedMitm'))
+        .use(require('unexpected-http'));
+
+    var handleRequest,
+        server,
+        serverAddress,
+        serverHostname,
+        serverUrl;
+    beforeEach(function () {
+        handleRequest = undefined;
+        server = http.createServer(function (req, res) {
+            res.sendDate = false;
+            handleRequest(req, res);
+        }).listen(59891);
+        serverAddress = server.address();
+        serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address;
+        serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/';
+    });
+
+    afterEach(function () {
+        server.close();
+    });
+
+    it('should record', function () {
+        handleRequest = function (req, res) {
+            res.statusCode = 405;
+            res.end();
+        };
+        return expect({
+            url: 'GET ' + serverUrl
+        }, 'with http mocked out', {
+            request: {
+                url: 'GET /', headers: { Host: '0.0.0.0:59891' }, host: '0.0.0.0',
+                port: 59891
+            },
+            response: 405
+        }, 'to yield response', 405);
+    });
+});

--- a/testdata/compound-injected.js
+++ b/testdata/compound-injected.js
@@ -1,0 +1,47 @@
+/*global describe, it, beforeEach, afterEach*/
+var http = require('http');
+var expect = require('unexpected');
+
+describe('example with http recorded and injected file', function () {
+    expect = expect.clone()
+        .use(require('../lib/unexpectedMitm'))
+        .use(require('unexpected-http'));
+
+    var handleRequest,
+        server,
+        serverAddress,
+        serverHostname,
+        serverUrl;
+    beforeEach(function () {
+        handleRequest = undefined;
+        server = http.createServer(function (req, res) {
+            res.sendDate = false;
+            handleRequest(req, res);
+        }).listen(59891);
+        serverAddress = server.address();
+        serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address;
+        serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/';
+    });
+
+    afterEach(function () {
+        server.close();
+    });
+
+    it('should record', function () {
+        handleRequest = function (req, res) {
+            res.statusCode = 405;
+            res.end();
+        };
+        return expect({
+            url: 'GET ' + serverUrl
+        }, 'with http mocked out', {
+            request: {
+                url: 'GET /',
+                headers: { Host: 'localhost:59891' },
+                host: 'localhost',
+                port: 59891
+            },
+            response: 405
+        }, 'to yield response', 405);
+    });
+});

--- a/testdata/compound.js
+++ b/testdata/compound.js
@@ -1,0 +1,39 @@
+/*global describe, it, beforeEach, afterEach*/
+var http = require('http');
+var expect = require('unexpected');
+
+describe('example with http recorded and injected file', function () {
+    expect = expect.clone()
+        .use(require('../lib/unexpectedMitm'))
+        .use(require('unexpected-http'));
+
+    var handleRequest,
+        server,
+        serverAddress,
+        serverHostname,
+        serverUrl;
+    beforeEach(function () {
+        handleRequest = undefined;
+        server = http.createServer(function (req, res) {
+            res.sendDate = false;
+            handleRequest(req, res);
+        }).listen(59891);
+        serverAddress = server.address();
+        serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address;
+        serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/';
+    });
+
+    afterEach(function () {
+        server.close();
+    });
+
+    it('should record', function () {
+        handleRequest = function (req, res) {
+            res.statusCode = 405;
+            res.end();
+        };
+        return expect({
+            url: 'GET ' + serverUrl
+        }, 'with http recorded and injected to yield response', 405);
+    });
+});

--- a/testdata/testfilecompound.js
+++ b/testdata/testfilecompound.js
@@ -1,0 +1,39 @@
+/*global describe, it, beforeEach, afterEach*/
+var http = require('http');
+var expect = require('unexpected');
+
+describe('example with http recorded and injected file', function () {
+    expect = expect.clone()
+        .use(require('../lib/unexpectedMitm'))
+        .use(require('unexpected-http'));
+
+    var handleRequest,
+        server,
+        serverAddress,
+        serverHostname,
+        serverUrl;
+    beforeEach(function () {
+        handleRequest = undefined;
+        server = http.createServer(function (req, res) {
+            res.sendDate = false;
+            handleRequest(req, res);
+        }).listen(59891);
+        serverAddress = server.address();
+        serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address;
+        serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/';
+    });
+
+    afterEach(function () {
+        server.close();
+    });
+
+    it('should record', function () {
+        handleRequest = function (req, res) {
+            res.statusCode = 405;
+            res.end();
+        };
+        return expect({
+            url: 'GET ' + serverUrl
+        }, 'with http recorded and injected', 'to yield response', 405);
+    });
+});


### PR DESCRIPTION
eg. 'with http recorded and injected to yield response'

// cc @alexjeffburke