### PR TITLE
Update Unexpected to 10.15.0, use expect.promise.fromNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "request": "2.53.0",
     "semver": "5.0.1",
     "sinon": "1.17.2",
-    "unexpected": "10.13.0",
+    "unexpected": "10.15.0",
     "unexpected-documentation-site-generator": "^4.0.0",
     "unexpected-express": "8.2.0",
     "unexpected-http": "5.4.0",

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -83,14 +83,8 @@ describe('unexpectedMitm', function () {
     expect.output.preferredWidth = 150;
 
     function createPemCertificate(certOptions) {
-        return expect.promise(function (resolve, reject) {
-            pem.createCertificate(function (err, certificateKeys) {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(certificateKeys);
-                }
-            });
+        return expect.promise.fromNode(function (cb) {
+            pem.createCertificate(cb);
         });
     }
 


### PR DESCRIPTION
@alexjeffburke Wasn't sure if you intended to stay on Unexpected 10.13.0 to be able to time the upcoming, promise-related fixes, so I put this on a branch for now. Merge whenever it fits with your plans :)