### PR TITLE
with http mocked out: Allow 'GET /foo' => { request: 'GET /foo', response: 200 } shorthand

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -759,10 +759,7 @@ module.exports = {
                 var shouldBeVerified = checkEnvFlag('UNEXPECTED_MITM_VERIFY') || expect.flags['and verified'];
                 var shouldReturnExtraInfo = expect.flags['with extra info'];
 
-                // Allow this shorthand in array mode:
-                // 'GET /foo' => { request: 'GET /foo', response: 200 }
-                // Doesn't work when providing a single string as that
-                // is reserved for loading the mock data from a file:
+                // Allow shorthand: 'GET /foo' => { request: 'GET /foo', response: 200 }
                 function normalizeRequestDescription(requestDescription) {
                     if (typeof requestDescription === 'string') {
                         return {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -753,7 +753,7 @@ module.exports = {
                     }
                 });
             })
-            .addAssertion('<any> with http mocked out [and verified] [with extra info] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
+            .addAssertion('<any> with http mocked out [and verified] [with extra info] <array|object|string> <assertion>', function (expect, subject, requestDescriptions) { // ...
                 expect.errorMode = 'nested';
                 var mitm = createMitm();
                 var shouldBeVerified = checkEnvFlag('UNEXPECTED_MITM_VERIFY') || expect.flags['and verified'];

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -759,15 +759,30 @@ module.exports = {
                 var shouldBeVerified = checkEnvFlag('UNEXPECTED_MITM_VERIFY') || expect.flags['and verified'];
                 var shouldReturnExtraInfo = expect.flags['with extra info'];
 
+                // Allow this shorthand in array mode:
+                // 'GET /foo' => { request: 'GET /foo', response: 200 }
+                // Doesn't work when providing a single string as that
+                // is reserved for loading the mock data from a file:
+                function normalizeRequestDescription(requestDescription) {
+                    if (typeof requestDescription === 'string') {
+                        return {
+                            request: requestDescription,
+                            response: 200
+                        };
+                    } else {
+                        return requestDescription;
+                    }
+                }
+
                 if (!Array.isArray(requestDescriptions)) {
                     if (typeof requestDescriptions === 'undefined') {
                         requestDescriptions = [];
                     } else {
-                        requestDescriptions = [requestDescriptions];
+                        requestDescriptions = [normalizeRequestDescription(requestDescriptions)];
                     }
                 } else {
                     // duplicate descriptions to allow array consumption
-                    requestDescriptions = requestDescriptions.slice(0);
+                    requestDescriptions = requestDescriptions.map(normalizeRequestDescription);
                 }
 
                 var verifyBlocks = requestDescriptions.map(function (description) {

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -2040,6 +2040,28 @@ describe('unexpectedMitm', function () {
 
     describe('using a string as a shorthand for a request with a 200 response', function () {
         it('should succeed', function () {
+            return expect('POST http://www.google.com/', 'with http mocked out', 'POST /', 'to yield response', 200);
+        });
+
+        it('should fail with a diff', function () {
+            return expect(
+                expect('GET http://www.google.com/', 'with http mocked out', 'POST /foo', 'to yield response', 400),
+                'to be rejected with',
+                "expected 'GET http://www.google.com/' with http mocked out 'POST /foo' to yield response 400\n" +
+                "\n" +
+                "GET / HTTP/1.1 // should be POST /foo\n" +
+                "               //\n" +
+                "               // -GET / HTTP/1.1\n" +
+                "               // +POST /foo HTTP/1.1\n" +
+                "Host: www.google.com\n" +
+                "\n" +
+                "HTTP/1.1 200 OK"
+            );
+        });
+    });
+
+    describe('using a string in an array as a shorthand for a request with a 200 response', function () {
+        it('should succeed', function () {
             return expect('POST http://www.google.com/', 'with http mocked out', [
                 'POST /'
             ], 'to yield response', 200);

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -2037,4 +2037,30 @@ describe('unexpectedMitm', function () {
             { request: { host: 'www.bing.com', headers: { Host: 'www.bing.com' } }, response: 200 }
         ], 'not to error');
     });
+
+    describe('using a string as a shorthand for a request with a 200 response', function () {
+        it('should succeed', function () {
+            return expect('POST http://www.google.com/', 'with http mocked out', [
+                'POST /'
+            ], 'to yield response', 200);
+        });
+
+        it('should fail with a diff', function () {
+            return expect(
+                expect('GET http://www.google.com/', 'with http mocked out', [
+                    'POST /foo'
+                ], 'to yield response', 400),
+                'to be rejected with',
+                "expected 'GET http://www.google.com/' with http mocked out [ 'POST /foo' ] to yield response 400\n" +
+                "\n" +
+                "GET / HTTP/1.1 // should be POST /foo\n" +
+                "               //\n" +
+                "               // -GET / HTTP/1.1\n" +
+                "               // +POST /foo HTTP/1.1\n" +
+                "Host: www.google.com\n" +
+                "\n" +
+                "HTTP/1.1 200 OK"
+            );
+        });
+    });
 });


### PR DESCRIPTION
Cannot support ... `'with http mocked out', 'GET /foo'` as that's reserved for loading the test data from a file on disc (https://github.com/unexpectedjs/unexpected-mitm/pull/22) -- unless we want to change that to be triggered by a flag.
