### PR TITLE
with http recorded: Preserve the fulfilment value of the assertion being delegated to

### DIFF
--- a/documentation/assertions/any/with-http-recorded.md
+++ b/documentation/assertions/any/with-http-recorded.md
@@ -10,8 +10,9 @@ describe('requests to a popular web search service', function () {
     it('should have a Content-Type', function () {
         return expect({
             url: 'GET https://www.google.co.uk',
-        }, 'with http recorded', 'to yield response', 200).then(function (exchange) {
-            expect(exchange.response.headers, 'to have property', 'Content-Type');
+        }, 'with http recorded', 'to yield response', 200).then(function (context) {
+            // context is provided by unexpected-http:
+            expect(context.httpResponse.headers, 'to satisfy', {'Content-Type': /html/});
         });
     });
 });

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -696,13 +696,13 @@ module.exports = {
 
                 expect.promise(function () {
                     return expect.shift();
-                }).caught(reject).then(function () {
+                }).caught(reject).then(function (value) {
                     recordedExchanges = recordedExchanges.map(trimRecordedExchange);
                     if (recordedExchanges.length === 1) {
                         recordedExchanges = recordedExchanges[0];
                     }
 
-                    resolve(recordedExchanges);
+                    resolve([value, recordedExchanges]);
                 });
             }).finally(function () {
                 mitm.disable();
@@ -712,7 +712,7 @@ module.exports = {
         var afterBlockRegistered = false;
 
         expect
-            .addAssertion('<any> with http recorded [and injected] <assertion>', function (expect, subject) {
+            .addAssertion('<any> with http recorded [and injected] [with extra info] <assertion>', function (expect, subject) {
                 var stack = callsite(),
                     injectIntoTest = this.flags['and injected'];
 
@@ -721,14 +721,18 @@ module.exports = {
                     afterBlockRegistered = true;
                 }
 
-                return executeMitm(expect, subject).then(function (recordedExchanges) {
+                return executeMitm(expect, subject).spread(function (value, recordedExchanges) {
                     if (injectIntoTest) {
                         var injectionCallsite = determineInjectionCallsite(stack);
                         if (injectionCallsite) {
                             recordPendingInjection(injectionCallsite, recordedExchanges);
                         }
                     }
-                    return recordedExchanges;
+                    if (expect.flags['with extra info']) {
+                        return [value, recordedExchanges];
+                    } else {
+                        return value;
+                    }
                 });
             })
             .addAssertion('<any> with http mocked out [and verified] [with extra info] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -35,11 +35,12 @@ describe('unexpectedMitm', function () {
         .use(require('unexpected-sinon'))
         .addAssertion('<any> with expected http recording <object> <assertion>', function (expect, subject, expectedRecordedExchanges) { // ...
             expect.errorMode = 'nested';
-            expect.args.splice(1, 0, 'with http recorded');
+            expect.args.splice(1, 0, 'with http recorded with extra info');
             return expect.promise(function () {
                 return expect.shift();
-            }).then(function (recordedExchanges) {
+            }).spread(function (value, recordedExchanges) {
                 expect(recordedExchanges, 'to equal', expectedRecordedExchanges);
+                return value;
             });
         })
         .addAssertion('<string> when injected becomes <string>', function (expect, subject, expectedFileName) {
@@ -1333,6 +1334,12 @@ describe('unexpectedMitm', function () {
                     }
                 }
             }, 'to yield response', 405);
+        });
+
+        it('should preserve the fulfilment value', function () {
+            return expect('foo', 'with http recorded', 'to match', /^(f)o/).then(function (matches) {
+                expect(matches, 'to satisfy', {0: 'fo', 1: 'f', index: 0});
+            });
         });
 
         it('should record an error', function () {


### PR DESCRIPTION
Also, add support for 'with extra info' flag to be used in the test suite.