### PR TITLE
wip: footgun protective boots.

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -829,8 +829,19 @@ module.exports = {
             .addAssertion('<any> with http mocked out [and verified] [with extra info] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
                 expect.errorMode = 'nested';
                 var mitm = createMitm();
+                var cleanedUpMitm = false;
                 var shouldBeVerified = checkEnvFlag('UNEXPECTED_MITM_VERIFY') || expect.flags['and verified'];
                 var shouldReturnExtraInfo = expect.flags['with extra info'];
+
+                // XXX: Register footgun detection in case an uncaught exception
+                // breaks the test in such a way that our finally block will not
+                // be called, and mitm thus will not be cleaned up.
+                afterEach(function () {
+                    if (!cleanedUpMitm) {
+                        cleanedUpMitm = true;
+                        mitm.disable();
+                    }
+                });
 
                 if (!Array.isArray(requestDescriptions)) {
                     if (typeof requestDescriptions === 'undefined') {
@@ -1120,6 +1131,7 @@ module.exports = {
                         }
                     });
                 }).finally(function () {
+                    cleanedUpMitm = true;
                     mitm.disable();
                 });
 


### PR DESCRIPTION
I just had a case where a failing test with http mocked out was causing a bunch of later mitm tests to fail miserably because mitm didn't get around to cleaning up.

@papandreou told me that I was suffering from the classic "uncaught exception in async flow breaking promises"-problem that unexpected also faces. 

This is a really naive fix that obviously needs improvement, but it saved the day in my test suite :-)