### PR TITLE
Deduplicate the HttpExchange assertion code via an early exit marker.

### DIFF
--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -8,6 +8,7 @@ var messy = require('messy'),
     path = require('path'),
     stream = require('stream'),
     urlModule = require('url'),
+    util = require('util'),
     memoizeSync = require('memoizesync'),
     callsite = require('callsite'),
     detectIndent = require('detect-indent'),
@@ -36,6 +37,13 @@ var pathIsAbsolute = path.isAbsolute || function (path) {
     }
     return false;
 };
+
+function EarlyExitError(message) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+};
+util.inherits(EarlyExitError, Error);
 
 function checkEnvFlag(varName) {
     return process.env[varName] === 'true';
@@ -1016,17 +1024,14 @@ module.exports = {
                             return expect.promise(function () {
                                 var assertionMockRequest = new messy.HttpRequest(requestProperties);
                                 trimHeadersLower(assertionMockRequest);
-                                var assertionExchange = new messy.HttpExchange({request: assertionMockRequest});
-                                if (mockResponse) {
-                                    assertionExchange.response = mockResponse;
-                                } else if (mockResponseError) {
-                                    assertionExchange.response = mockResponseError;
-                                }
-                                return expect(assertionExchange, 'to satisfy', {request: expectedRequestProperties});
+                                return expect(assertionMockRequest, 'to satisfy', expectedRequestProperties);
                             }).then(function () {
                                 expect.errorMode = originalErrorMode;
                                 // continue thus respond
                                 deliverMockResponse(mockResponse, mockResponseError);
+                            }).catch(function (e) {
+                                assertMockResponse(mockResponse, mockResponseError);
+                                throw new EarlyExitError('Seen request did not match the expected request.');
                             });
                         }).caught(function (e) {
                             /*
@@ -1047,7 +1052,11 @@ module.exports = {
                                  * reject the assertion. This is only safe with
                                  * Unexpected 10.15.x and above.
                                  */
-                                reject(e);
+                                if (e.name === 'EarlyExitError') {
+                                    resolve([null, httpConversation, httpConversationSatisfySpec]);
+                                } else {
+                                    reject(e);
+                                }
                             }
                         });
 

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -362,6 +362,7 @@ describe('unexpectedMitm', function () {
                         "POST / HTTP/1.1\n" +
                         "Host: www.google.com\n" +
                         "Content-Type: application/json\n" +
+                        "Content-Length: 11\n" +
                         "\n" +
                         "expected { foo: 123 } when delayed a little bit to equal { foo: 456 }\n" +
                         "\n" +
@@ -756,6 +757,7 @@ describe('unexpectedMitm', function () {
                         'POST / HTTP/1.1\n' +
                         'Host: www.google.com\n' +
                         'Content-Type: application/json\n' +
+                        'Content-Length: 11\n' +
                         '\n' +
                         '{\n' +
                         '  foo: 123 // should equal 456\n' +


### PR DESCRIPTION
@papandreou would be interested in your taking a look at this - on the one hand, it removes a slightly nasty bit of duplication.

In addition though, it is something of a step toward splitting mocking from assertion. The behaviour of this code is have only single point where we check the HttpExchange, and in the longer term that could be extended to the exchange itself containing information that an early exit occurred.