### PR TITLE
Timeline containing exchange or named error events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "6"

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -192,12 +192,22 @@ function trimHeadersLower(message) {
 
 function UnexpectedMitmMocker(options) {
     this.descriptions = options.descriptions || [];
+    this.timeline = null;
+    this.fulfilmentValue = null;
+
+    var that = this;
+    Object.defineProperty(this, 'isComplete', {
+        get: function () {
+            return that.timeline !== null;
+        }
+    });
 }
 
 UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
     consumptionFunction = consumptionFunction || function () {
         Promise.resolve(null);
     };
+    var that = this;
     var requestDescriptions = this.descriptions;
 
     var mitm = createMitm();
@@ -506,12 +516,18 @@ UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
     }).then(function (fulfilmentValue) {
         cleanup();
 
+        that.timeline = timeline;
+        that.fulfilmentValue = fulfilmentValue;
+
         return {
             timeline: timeline,
             fulfilmentValue: fulfilmentValue
         };
     }).catch(function () {
         cleanup();
+
+        that.timeline = timeline;
+        that.fulfilmentValue = null;
 
         // given we will later fail on "to satisfy" pass a null fulfilment value
         return {

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -1,0 +1,498 @@
+var _ = require('underscore');
+var createMitm = require('mitm-papandreou');
+var http = require('http');
+var https = require('https');
+var messy = require('messy');
+var stream = require('stream');
+var unexpected = require('unexpected');
+var unexpectedMessy = require('unexpected-messy');
+
+var consumeReadableStream = require('./consumeReadableStream');
+var createSerializedRequestHandler = require('./createSerializedRequestHandler');
+var errors = require('./errors');
+var formatHeaderObj = require('./formatHeaderObj');
+var resolveExpectedRequestProperties = require('./resolveExpectedRequestProperties');
+
+var expect = unexpected.clone().use(unexpectedMessy);
+
+var isNodeZeroTen = !!process.version.match(/v0.10/);
+
+function calculateBodyByteCount(chunk) {
+    var trailerIdx = findHeaderSeparator(chunk);
+    if (trailerIdx !== -1) {
+        return chunk.slice(trailerIdx + 4).length;
+    }
+
+    return 0;
+}
+
+function createMockResponse(responseProperties) {
+    var mockResponse = new messy.HttpResponse(responseProperties);
+    mockResponse.statusCode = mockResponse.statusCode || 200;
+    mockResponse.protocolName = mockResponse.protocolName || 'HTTP';
+    mockResponse.protocolVersion = mockResponse.protocolVersion || '1.1';
+    mockResponse.statusMessage = mockResponse.statusMessage || http.STATUS_CODES[mockResponse.statusCode];
+    return mockResponse;
+}
+
+function getMockResponse(responseProperties) {
+    var mockResponse;
+    var mockResponseError;
+    if (Object.prototype.toString.call(responseProperties) === '[object Error]') {
+        mockResponseError = responseProperties;
+    } else {
+        mockResponse = createMockResponse(responseProperties);
+    }
+
+    return expect.promise(function () {
+        if (!mockResponseError && mockResponse && mockResponse.body && typeof mockResponse.body.pipe === 'function') {
+            return consumeReadableStream(mockResponse.body).then(function (result) {
+                if (result.error) {
+                    mockResponseError = result.error;
+                }
+                if (result.body) {
+                    mockResponse.unchunkedBody = result.body;
+                }
+            });
+        }
+    }).then(function () {
+        if (mockResponse && !mockResponseError && (Array.isArray(mockResponse.body) || (mockResponse.body && typeof mockResponse.body === 'object' && (typeof Buffer === 'undefined' || !Buffer.isBuffer(mockResponse.body))))) {
+            if (!mockResponse.headers.has('Content-Type')) {
+                mockResponse.headers.set('Content-Type', 'application/json');
+            }
+        }
+        return [ mockResponse, mockResponseError ];
+    });
+}
+
+function findHeaderSeparator(chunk) {
+    return chunk.toString().indexOf('\r\n\r\n');
+}
+
+function isTrailerChunk(chunk) {
+    return chunk.slice(-5).toString() === '0\r\n\r\n';
+}
+
+function attachConnectionHook(connection, callback) {
+    var bodyByteCount = 0;
+    var contentLengthByteCount = 0;
+    var hasContentLength = false;
+    var rawChunks = [];
+    var sawHeaders = false;
+    var _write = connection._write;
+
+    /*
+     * wrap low level write to gather response data and return raw data
+     * to callback when entire response is written
+     */
+    connection._write = function (chunk, encoding, cb) {
+        chunk = Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk);
+
+        rawChunks.push(chunk);
+
+        if (!sawHeaders) {
+            var chunkString = chunk.toString();
+            var match;
+
+            match = chunkString.match(/^Transfer-Encoding: /m);
+            if (match) {
+                sawHeaders = true;
+            }
+
+            match = chunkString.match(/^Content-Length: (\d+)/m);
+            if (match) {
+                // handle the current chunk containing body bytes
+                bodyByteCount = calculateBodyByteCount(chunk);
+                contentLengthByteCount = +match[1];
+                hasContentLength = true;
+                sawHeaders = true;
+            }
+        } else {
+            bodyByteCount += chunk.length;
+        }
+
+        if ((isTrailerChunk(chunk) && !hasContentLength) ||
+                (hasContentLength && bodyByteCount === contentLengthByteCount)) {
+            /*
+             * explicitly execute the callback returning raw data here
+             * to ensure it is run before issuing the final write which
+             * will complete the request on the wire
+             */
+            callback(null, Buffer.concat(rawChunks));
+        }
+
+        _write.call(connection, chunk, encoding, cb);
+    };
+}
+
+function attachResponseHooks(res, callback) {
+    var hasEnded = false; // keep track of whether res.end() has been called
+
+    attachConnectionHook(res.connection, function (err, rawBuffer) {
+        if (hasEnded) {
+            callback(null, rawBuffer);
+        }
+    });
+
+    ['end', 'destroy'].forEach(function (methodName) {
+        var orig = res[methodName];
+        res[methodName] = function (chunk, encoding) {
+            if (methodName === 'end') {
+                hasEnded = true;
+            }
+
+            var returnValue = orig.apply(this, arguments);
+
+            if (methodName === 'destroy') {
+                hasEnded = true;
+                callback(null);
+            }
+
+            // unconditionally return value given we do not wrap write
+            return returnValue;
+        };
+    });
+}
+
+function observeResponse(res) {
+    return expect.promise(function (resolve, reject) {
+        attachResponseHooks(res, function (err, rawBuffer) {
+            resolve(rawBuffer);
+        });
+    });
+}
+
+function trimMockResponse(mockResponse) {
+    var responseProperties = {};
+    responseProperties.statusCode = mockResponse.statusCode;
+    responseProperties.statusMessage = mockResponse.statusMessage;
+    responseProperties.protocolName = mockResponse.protocolName;
+    responseProperties.protocolVersion = mockResponse.protocolVersion;
+    responseProperties.headers = formatHeaderObj(mockResponse.headers.valuesByName);
+
+    if (mockResponse.body) {
+        // read out the messy decoded body
+        responseProperties.body = mockResponse.body;
+    }
+
+    return responseProperties;
+}
+
+function trimHeadersLower(message) {
+    delete message.headers.valuesByName['content-length'];
+    delete message.headers.valuesByName['transfer-encoding'];
+    delete message.headers.valuesByName.connection;
+    delete message.headers.valuesByName.date;
+}
+
+
+function UnexpectedMitmMocker(options) {
+    this.descriptions = options.descriptions || [];
+}
+
+UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
+    consumptionPromise = consumptionPromise || expect.promise.Promise.resolve(null);
+    var requestDescriptions = this.descriptions;
+
+    var mitm = createMitm();
+
+    // Keep track of the current requestDescription
+    var nextRequestDescriptionIndex = 0;
+
+    // Keep track of the http/https agents that we have seen
+    // during the test so we can clean up afterwards:
+    var seenAgents = [];
+
+    // accumulator for events
+    var timeline = [];
+
+    return expect.promise(function (resolve, reject) {
+        mitm.on('request', createSerializedRequestHandler(function (req, res) {
+            if (!res.connection) {
+                // I've observed some cases where keep-alive is
+                // being used and we end up with an extra "phantom
+                // request event" even though only requeest is being
+                // issued. Seems like a bug in mitm.
+                // It goes without saying that we should try to get
+                // rid of this. Hopefully something will happen
+                // on https://github.com/moll/node-mitm/pull/36
+                return;
+            }
+            var clientSocket = req.connection._mitm.client;
+            var clientSocketOptions = req.connection._mitm.opts;
+            if (typeof clientSocketOptions.port === 'string') {
+                // The port could have been defined as a string in a 3rdparty library doing the http(s) call, and that seems to be valid use of the http(s) module
+                clientSocketOptions = _.defaults({
+                    port: parseInt(clientSocketOptions.port, 10)
+                }, clientSocketOptions);
+            }
+            var agent = clientSocketOptions.agent || (res.connection.encrypted ? https : http).globalAgent;
+            if (seenAgents.indexOf(agent) === -1) {
+                seenAgents.push(agent);
+            }
+            var currentDescription = requestDescriptions[nextRequestDescriptionIndex];
+            nextRequestDescriptionIndex += 1;
+            var hasRequestDescription = !!currentDescription,
+                metadata =
+                    _.defaults(
+                        { encrypted: Boolean(res.connection.encrypted) },
+                        _.pick(clientSocketOptions, messy.HttpRequest.metadataPropertyNames),
+                        _.pick(clientSocketOptions && clientSocketOptions.agent && clientSocketOptions.agent.options, messy.HttpRequest.metadataPropertyNames)
+                    ),
+                requestDescription = currentDescription,
+                requestProperties,
+                responseProperties = requestDescription && requestDescription.response,
+                expectedRequestProperties;
+
+            expect.promise(function () {
+                expectedRequestProperties = resolveExpectedRequestProperties(requestDescription && requestDescription.request);
+            }).then(function () {
+                return consumeReadableStream(req, {skipConcat: true});
+            }).then(function (result) {
+                if (result.error) {
+                    // TODO: Consider adding support for recording this (the request erroring out while we're consuming it)
+                    throw result.error;
+                }
+                requestProperties = _.extend({
+                    method: req.method,
+                    path: req.url,
+                    protocolName: 'HTTP',
+                    protocolVersion: req.httpVersion,
+                    headers: req.headers,
+                    unchunkedBody: Buffer.concat(result.body)
+                }, metadata);
+
+                if (!hasRequestDescription) {
+                    // there was no mock so arrange "<no response>"
+                    assertMockResponse(null);
+
+                    /*
+                     * We wish to cause the generation of a diff
+                     * so we arrange to enter our 'success' path
+                     * but ensure the delegated assertion fully
+                     * completes by signalling an error condition.
+                     *
+                     * Note the use of the single reject/resolve
+                     * behaviour of promises: while the delegated
+                     * assertion is reject()ed, we have already
+                     * resolve()d thus the rejection of the former
+                     * is effectively ignored and we proceed with
+                     * our output.
+                     */
+
+                    // cancel the delegated assertion
+                    throw new errors.SawUnexpectedRequestsError('unexpected-mitm: Saw unexpected requests.');
+                }
+
+                if (typeof responseProperties === 'function') {
+                    // reset the readable req stream state
+                    stream.Readable.call(req);
+
+                    // read stream data from the buffered chunks
+                    req._read = function () {
+                        this.push(result.body.shift() || null);
+                    };
+
+                    if (isNodeZeroTen) {
+                        /*
+                         * As is mentioned in the streams documentation this
+                         * call can be issued to kick some of the machinery
+                         * and is apparently done within the standard lib.
+                         */
+                        req.read(0);
+                    }
+
+                    // call response function inside a promise to catch exceptions
+                    return expect.promise(function () {
+                        responseProperties(req, res);
+                    }).then(function () {
+                        return [null, null];
+                    }).caught(function (err) {
+                        // ensure delivery of the caught error to the underlying socket
+                        return [null, err];
+                    });
+                } else {
+                    return getMockResponse(responseProperties);
+                }
+            }).spread(function (mockResponse, mockResponseError) {
+                if (!(mockResponse || mockResponseError)) {
+                    return;
+                }
+
+                return expect.promise(function () {
+                    var assertionMockRequest = new messy.HttpRequest(requestProperties);
+                    trimHeadersLower(assertionMockRequest);
+
+                    expect.errorMode = 'default';
+                    return expect(assertionMockRequest, 'to satisfy', expectedRequestProperties);
+                }).then(function () {
+                    deliverMockResponse(mockResponse, mockResponseError);
+                }).catch(function (e) {
+                    assertMockResponse(mockResponse, mockResponseError);
+                    throw new errors.EarlyExitError('Seen request did not match the expected request.');
+                });
+            }).catch(function (e) {
+                /*
+                 * Given an error occurs, the deferred assertion
+                 * will still be pending and must be completed. We
+                 * do this by signalling the error on the socket.
+                 */
+
+                // cancel the delegated assertion
+                try {
+                    clientSocket.emit('error', e);
+                } finally {
+                    /*
+                     * If an something was thrown trying to signal
+                     * an error we have little choice but to try to
+                     * reject the assertion. This is only safe with
+                     * Unexpected 10.15.x and above.
+                     */
+
+                    timeline.push(e);
+                    reject(e);
+                }
+            });
+
+            function assertMockResponse(mockResponse, mockResponseError) {
+                var mockRequest = new messy.HttpRequest(requestProperties);
+
+                var httpExchange = new messy.HttpExchange({request: mockRequest});
+                if (mockResponse) {
+                    httpExchange.response = mockResponse;
+                } else if (mockResponseError) {
+                    httpExchange.response = mockResponseError;
+                }
+
+                var eventSpec = null;
+                // only attempt request validation with a mock
+                if (hasRequestDescription) {
+                    eventSpec = {request: expectedRequestProperties};
+                }
+
+                /*
+                 * We explicitly do not complete the promise
+                 * when the last request for which we have a
+                 * mock is seen.
+                 *
+                 * Instead simply record any exchanges that
+                 * passed through and defer the resolution or
+                 * rejection to the handler functions attached
+                 * to the delegated assertion execution below.
+                 */
+
+                timeline.push({
+                    exchange: httpExchange,
+                    spec: eventSpec
+                });
+            }
+
+            function deliverMockResponse(mockResponse, mockResponseError) {
+                setImmediate(function () {
+                    var nonEmptyMockResponse = false;
+                    if (mockResponse) {
+                        res.statusCode = mockResponse.statusCode;
+                        mockResponse.headers.getNames().forEach(function (headerName) {
+                            mockResponse.headers.getAll(headerName).forEach(function (value) {
+                                nonEmptyMockResponse = true;
+                                res.setHeader(headerName, value);
+                            });
+                        });
+                        var unchunkedBody = mockResponse.unchunkedBody;
+                        if (typeof unchunkedBody !== 'undefined' && unchunkedBody.length > 0) {
+                            nonEmptyMockResponse = true;
+                            res.write(unchunkedBody);
+                        } else if (nonEmptyMockResponse) {
+                            res.writeHead(res.statusCode || 200);
+                        }
+                    }
+                    if (mockResponseError) {
+                        setImmediate(function () {
+                            clientSocket.emit('error', mockResponseError);
+                            assertMockResponse(mockResponse, mockResponseError);
+                        });
+                    } else {
+                        res.end();
+                    }
+                });
+            }
+
+            /*
+             * hook final write callback to record raw data and immediately
+             * assert request so it occurs prior to request completion
+             */
+            observeResponse(res).then(function (rawBuffer) {
+                var mockResponse = createMockResponse(rawBuffer);
+                assertMockResponse(mockResponse);
+            });
+        }));
+
+        expect.promise(function () {
+            return consumptionPromise();
+        }).then(function (fulfilmentValue) {
+            /*
+             * Handle the case of specified but unprocessed mocks.
+             * If there were none remaining immediately complete.
+             *
+             * Where the driving assertion resolves we must check
+             * if any mocks still exist. If so, we add them to the
+             * set of expected exchanges and resolve the promise.
+             */
+            var hasRemainingRequestDescriptions = nextRequestDescriptionIndex < requestDescriptions.length;
+            if (hasRemainingRequestDescriptions) {
+                // exhaust remaining mocks using a promises chain
+                return (function nextItem() {
+                    var remainingDescription = requestDescriptions[nextRequestDescriptionIndex];
+                    nextRequestDescriptionIndex += 1;
+                    if (remainingDescription) {
+                        var expectedRequestProperties;
+
+                        return expect.promise(function () {
+                            expectedRequestProperties = resolveExpectedRequestProperties(remainingDescription.request);
+                        }).then(function () {
+                            return getMockResponse(remainingDescription.response);
+                        }).spread(function (mockResponse, mockResponseError) {
+                            var spec = {
+                                request: expectedRequestProperties,
+                                response: mockResponseError || trimMockResponse(mockResponse)
+                            };
+
+                            timeline.push({ spec: spec });
+
+                            return nextItem();
+                        });
+                    } else {
+                        throw new errors.UnexercisedMocksError();
+                    }
+                })();
+            } else {
+                resolve(fulfilmentValue);
+            }
+        }).catch(function (e) {
+            timeline.push(e);
+            reject(e);
+        });
+    }).then(function (fulfilmentValue) {
+        return {
+            timeline: timeline,
+            fulfilmentValue: fulfilmentValue
+        };
+    }).catch(function () {
+        // given we will later fail on "to satisfy" pass a null fulfilment value
+        return {
+            timeline: timeline,
+            fulfilmentValue: null
+        };
+    }).finally(function () {
+        seenAgents.forEach(function (agent) {
+            if (agent.freeSockets) {
+                Object.keys(agent.freeSockets).forEach(function (key) {
+                    agent.freeSockets[key] = [];
+                });
+            }
+        });
+        mitm.disable();
+    });
+};
+
+module.exports = UnexpectedMitmMocker;

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -361,21 +361,19 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
                  * will still be pending and must be completed. We
                  * do this by signalling the error on the socket.
                  */
-
-                // cancel the delegated assertion
                 try {
                     clientSocket.emit('error', e);
-                } finally {
+                } catch (e) {
                     /*
                      * If an something was thrown trying to signal
-                     * an error we have little choice but to try to
+                     * an error we have little choice but to simply
                      * reject the assertion. This is only safe with
                      * Unexpected 10.15.x and above.
                      */
-
-                    timeline.push(e);
-                    reject(e);
                 }
+
+                timeline.push(e);
+                reject(e);
             });
 
             function assertMockResponse(mockResponse, mockResponseError) {

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -82,6 +82,7 @@ function attachConnectionHook(connection, callback) {
     var bodyByteCount = 0;
     var contentLengthByteCount = 0;
     var hasContentLength = false;
+    var hasTransferEncoding = false;
     var rawChunks = [];
     var sawHeaders = false;
     var _write = connection._write;
@@ -99,13 +100,14 @@ function attachConnectionHook(connection, callback) {
             var chunkString = chunk.toString();
             var match;
 
-            match = chunkString.match(/^Transfer-Encoding: /m);
+            match = chunkString.match(/^Transfer-Encoding: /mi);
             if (match) {
+                hasTransferEncoding = true;
                 sawHeaders = true;
             }
 
-            match = chunkString.match(/^Content-Length: (\d+)/m);
-            if (match) {
+            match = chunkString.match(/^Content-Length: (\d+)/mi);
+            if (match && !hasTransferEncoding) {
                 // handle the current chunk containing body bytes
                 bodyByteCount = calculateBodyByteCount(chunk);
                 contentLengthByteCount = +match[1];

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -13,6 +13,7 @@ var createSerializedRequestHandler = require('./createSerializedRequestHandler')
 var errors = require('./errors');
 var formatHeaderObj = require('./formatHeaderObj');
 var resolveExpectedRequestProperties = require('./resolveExpectedRequestProperties');
+var trimHeadersLower = require('./trimHeadersLower');
 
 var expect = unexpected.clone().use(unexpectedMessy);
 
@@ -180,13 +181,6 @@ function trimMockResponse(mockResponse) {
     }
 
     return responseProperties;
-}
-
-function trimHeadersLower(message) {
-    delete message.headers.valuesByName['content-length'];
-    delete message.headers.valuesByName['transfer-encoding'];
-    delete message.headers.valuesByName.connection;
-    delete message.headers.valuesByName.date;
 }
 
 

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -191,9 +191,6 @@ function UnexpectedMitmMocker(options) {
 }
 
 UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
-    consumptionFunction = consumptionFunction || function () {
-        Promise.resolve(null);
-    };
     var that = this;
     var requestDescriptions = this.requestDescriptions;
 

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -378,17 +378,17 @@ UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
             function assertMockResponse(mockResponse, mockResponseError) {
                 var mockRequest = new messy.HttpRequest(requestProperties);
 
-                var httpExchange = new messy.HttpExchange({request: mockRequest});
+                var exchange = new messy.HttpExchange({ request: mockRequest });
                 if (mockResponse) {
-                    httpExchange.response = mockResponse;
+                    exchange.response = mockResponse;
                 } else if (mockResponseError) {
-                    httpExchange.response = mockResponseError;
+                    exchange.response = mockResponseError;
                 }
 
-                var eventSpec = null;
+                var spec = null;
                 // only attempt request validation with a mock
                 if (hasRequestDescription) {
-                    eventSpec = {request: expectedRequestProperties};
+                    spec = { request: expectedRequestProperties };
                 }
 
                 /*
@@ -403,8 +403,8 @@ UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
                  */
 
                 timeline.push({
-                    exchange: httpExchange,
-                    spec: eventSpec
+                    exchange: exchange,
+                    spec: spec
                 });
             }
 

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -194,8 +194,10 @@ function UnexpectedMitmMocker(options) {
     this.descriptions = options.descriptions || [];
 }
 
-UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
-    consumptionPromise = consumptionPromise || expect.promise.Promise.resolve(null);
+UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
+    consumptionFunction = consumptionFunction || function () {
+        Promise.resolve(null);
+    };
     var requestDescriptions = this.descriptions;
 
     var mitm = createMitm();
@@ -452,7 +454,7 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
         // handle synchronous throws
         var consumer;
         try {
-            consumer = consumptionPromise();
+            consumer = consumptionFunction();
         } catch (e) {
             timeline.push(e);
             return reject(e);

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -185,7 +185,7 @@ function trimMockResponse(mockResponse) {
 
 
 function UnexpectedMitmMocker(options) {
-    this.descriptions = options.descriptions || [];
+    this.requestDescriptions = options.requestDescriptions || [];
     this.timeline = null;
     this.fulfilmentValue = null;
 }
@@ -195,7 +195,7 @@ UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
         Promise.resolve(null);
     };
     var that = this;
-    var requestDescriptions = this.descriptions;
+    var requestDescriptions = this.requestDescriptions;
 
     var mitm = createMitm();
 

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -458,7 +458,11 @@ UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
         // handle synchronous throws
         var consumer;
         try {
-            consumer = consumptionFunction();
+            var consumerResult = consumptionFunction();
+            // ensure consumption function returned a promise
+            consumer = Promise.resolve().then(function () {
+                return consumerResult;
+            });
         } catch (e) {
             timeline.push(e);
             return reject(e);

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -459,10 +459,8 @@ UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {
         var consumer;
         try {
             var consumerResult = consumptionFunction();
-            // ensure consumption function returned a promise
-            consumer = Promise.resolve().then(function () {
-                return consumerResult;
-            });
+            // ensure consumption function result is a promises
+            consumer = Promise.resolve(consumerResult);
         } catch (e) {
             timeline.push(e);
             return reject(e);

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -188,13 +188,6 @@ function UnexpectedMitmMocker(options) {
     this.descriptions = options.descriptions || [];
     this.timeline = null;
     this.fulfilmentValue = null;
-
-    var that = this;
-    Object.defineProperty(this, 'isComplete', {
-        get: function () {
-            return that.timeline !== null;
-        }
-    });
 }
 
 UnexpectedMitmMocker.prototype.mock = function mock(consumptionFunction) {

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -1,3 +1,4 @@
+/*global Promise:false*/
 var _ = require('underscore');
 var createMitm = require('mitm-papandreou');
 var http = require('http');
@@ -61,7 +62,10 @@ function getMockResponse(responseProperties) {
                 mockResponse.headers.set('Content-Type', 'application/json');
             }
         }
-        return [ mockResponse, mockResponseError ];
+        return {
+            response: mockResponse,
+            error: mockResponseError
+        };
     });
 }
 
@@ -206,7 +210,18 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
     // accumulator for events
     var timeline = [];
 
-    return expect.promise(function (resolve, reject) {
+    function cleanup() {
+        seenAgents.forEach(function (agent) {
+            if (agent.freeSockets) {
+                Object.keys(agent.freeSockets).forEach(function (key) {
+                    agent.freeSockets[key] = [];
+                });
+            }
+        });
+        mitm.disable();
+    }
+
+    return new Promise(function (resolve, reject) {
         mitm.on('request', createSerializedRequestHandler(function (req, res) {
             if (!res.connection) {
                 // I've observed some cases where keep-alive is
@@ -244,7 +259,7 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
                 responseProperties = requestDescription && requestDescription.response,
                 expectedRequestProperties;
 
-            expect.promise(function () {
+            Promise.resolve().then(function () {
                 expectedRequestProperties = resolveExpectedRequestProperties(requestDescription && requestDescription.request);
             }).then(function () {
                 return consumeReadableStream(req, {skipConcat: true});
@@ -303,23 +318,32 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
                     }
 
                     // call response function inside a promise to catch exceptions
-                    return expect.promise(function () {
+                    return Promise.resolve().then(function () {
                         responseProperties(req, res);
                     }).then(function () {
-                        return [null, null];
-                    }).caught(function (err) {
+                        return {
+                            response: null,
+                            error: null
+                        };
+                    }).catch(function (err) {
                         // ensure delivery of the caught error to the underlying socket
-                        return [null, err];
+                        return {
+                            response: null,
+                            error: err
+                        };
                     });
                 } else {
                     return getMockResponse(responseProperties);
                 }
-            }).spread(function (mockResponse, mockResponseError) {
+            }).then(function (result) {
+                var mockResponse = result.response;
+                var mockResponseError = result.error;
+
                 if (!(mockResponse || mockResponseError)) {
                     return;
                 }
 
-                return expect.promise(function () {
+                return Promise.resolve().then(function () {
                     var assertionMockRequest = new messy.HttpRequest(requestProperties);
                     trimHeadersLower(assertionMockRequest);
 
@@ -427,9 +451,16 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
             });
         }));
 
-        expect.promise(function () {
-            return consumptionPromise();
-        }).then(function (fulfilmentValue) {
+        // handle synchronous throws
+        var consumer;
+        try {
+            consumer = consumptionPromise();
+        } catch (e) {
+            timeline.push(e);
+            return reject(e);
+        }
+
+        consumer.then(function (fulfilmentValue) {
             /*
              * Handle the case of specified but unprocessed mocks.
              * If there were none remaining immediately complete.
@@ -447,14 +478,14 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
                     if (remainingDescription) {
                         var expectedRequestProperties;
 
-                        return expect.promise(function () {
+                        return Promise.resolve().then(function () {
                             expectedRequestProperties = resolveExpectedRequestProperties(remainingDescription.request);
                         }).then(function () {
                             return getMockResponse(remainingDescription.response);
-                        }).spread(function (mockResponse, mockResponseError) {
+                        }).then(function (result) {
                             var spec = {
                                 request: expectedRequestProperties,
-                                response: mockResponseError || trimMockResponse(mockResponse)
+                                response: result.error || trimMockResponse(result.response)
                             };
 
                             timeline.push({ spec: spec });
@@ -473,25 +504,20 @@ UnexpectedMitmMocker.prototype.mock = function (consumptionPromise) {
             reject(e);
         });
     }).then(function (fulfilmentValue) {
+        cleanup();
+
         return {
             timeline: timeline,
             fulfilmentValue: fulfilmentValue
         };
     }).catch(function () {
+        cleanup();
+
         // given we will later fail on "to satisfy" pass a null fulfilment value
         return {
             timeline: timeline,
             fulfilmentValue: null
         };
-    }).finally(function () {
-        seenAgents.forEach(function (agent) {
-            if (agent.freeSockets) {
-                Object.keys(agent.freeSockets).forEach(function (key) {
-                    agent.freeSockets[key] = [];
-                });
-            }
-        });
-        mitm.disable();
     });
 };
 

--- a/lib/consumeReadableStream.js
+++ b/lib/consumeReadableStream.js
@@ -1,10 +1,9 @@
-var expect = require('unexpected');
-
+/*global Promise:false*/
 module.exports = function consumeReadableStream(readableStream, options) {
     options = options || {};
     var skipConcat = !!options.skipConcat;
 
-    return expect.promise(function (resolve, reject) {
+    return new Promise(function (resolve, reject) {
         var chunks = [];
         readableStream.on('data', function (chunk) {
             chunks.push(chunk);

--- a/lib/consumeReadableStream.js
+++ b/lib/consumeReadableStream.js
@@ -1,0 +1,17 @@
+var expect = require('unexpected');
+
+module.exports = function consumeReadableStream(readableStream, options) {
+    options = options || {};
+    var skipConcat = !!options.skipConcat;
+
+    return expect.promise(function (resolve, reject) {
+        var chunks = [];
+        readableStream.on('data', function (chunk) {
+            chunks.push(chunk);
+        }).on('end', function (chunk) {
+            resolve({ body: skipConcat ? chunks : Buffer.concat(chunks) });
+        }).on('error', function (err) {
+            resolve({ body: skipConcat ? chunks : Buffer.concat(chunks), error: err });
+        });
+    });
+};

--- a/lib/createSerializedRequestHandler.js
+++ b/lib/createSerializedRequestHandler.js
@@ -1,0 +1,32 @@
+module.exports = function createSerializedRequestHandler(onRequest) {
+    var activeRequest = false,
+        requestQueue = [];
+
+    function processNextRequest() {
+        function cleanUpAndProceed() {
+            if (activeRequest) {
+                activeRequest = false;
+                setImmediate(processNextRequest);
+            }
+        }
+        while (requestQueue.length > 0 && !activeRequest) {
+            activeRequest = true;
+            var reqAndRes = requestQueue.shift(),
+                req = reqAndRes[0],
+                res = reqAndRes[1],
+                resEnd = res.end;
+            res.end = function () {
+                resEnd.apply(this, arguments);
+                cleanUpAndProceed();
+            };
+            // This happens upon an error, so we need to make sure that we catch that case also:
+            res.on('close', cleanUpAndProceed);
+            onRequest(req, res);
+        }
+    }
+
+    return function (req, res) {
+        requestQueue.push([req, res]);
+        processNextRequest();
+    };
+};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,14 @@
+var createError = require('createerror');
+
+// base error
+var UnexpectedMitmError = createError({ name: 'UnexpectedMitmError' });
+// marker errors
+var EarlyExitError = createError({ name: 'EarlyExitError' }, UnexpectedMitmError);
+var SawUnexpectedRequestsError = createError({ name: 'SawUnexpectedRequestsError' }, UnexpectedMitmError);
+var UnexercisedMocksError = createError({ name: 'UnexercisedMocksError' }, UnexpectedMitmError);
+
+
+exports.UnexpectedMitmError = UnexpectedMitmError;
+exports.EarlyExitError = EarlyExitError;
+exports.SawUnexpectedRequestsError = SawUnexpectedRequestsError;
+exports.UnexercisedMocksError = UnexercisedMocksError;

--- a/lib/formatHeaderObj.js
+++ b/lib/formatHeaderObj.js
@@ -1,0 +1,9 @@
+var messy = require('messy');
+
+module.exports = function formatHeaderObj(headerObj) {
+    var result = {};
+    Object.keys(headerObj).forEach(function (headerName) {
+        result[messy.formatHeaderName(headerName)] = headerObj[headerName];
+    });
+    return result;
+};

--- a/lib/mockerAssertions.js
+++ b/lib/mockerAssertions.js
@@ -1,0 +1,86 @@
+var messy = require('messy');
+var trimHeadersLower = require('./trimHeadersLower');
+var UnexpectedMitmMocker = require('./UnexpectedMitmMocker');
+
+module.exports = {
+    name: 'unexpected-mitm-mocker',
+    version: require('../package.json').version,
+    installInto: function (expect) {
+        expect = expect.child()
+            .use(require('unexpected-messy'))
+            .exportType({
+                name: 'UnexpectedMitmMocker',
+                base: 'object',
+                identify: function (obj) {
+                    return obj instanceof UnexpectedMitmMocker;
+                }
+            })
+            .exportAssertion('<UnexpectedMitmMocker> to be complete [with extra info]', function (expect, subject) {
+                var shouldReturnExtraInfo = expect.flags['with extra info'];
+
+                return expect.promise(function () {
+                    return subject;
+                }).then(function (result) {
+                    return [result.timeline, result.fulfilmentValue];
+                }).spread(function (timeline, fulfilmentValue) {
+                    var lastEventOrError = null;
+
+                    // pull out the last event if it exists
+                    if (timeline.length > 0) {
+                        lastEventOrError = timeline[timeline.length - 1];
+                    }
+
+                    if (lastEventOrError instanceof Error) {
+                        var name = lastEventOrError.name;
+                        if (name === 'Error' || name === 'UnexpectedError') {
+                            throw lastEventOrError;
+                        } else if (name === 'EarlyExitError') {
+                            // in the case of an early exirt error we need
+                            // to generate a diff from the last recorded
+                            // event & spec
+                            var failedEvent = timeline[timeline.length - 2];
+                            var failedExchange = failedEvent.exchange;
+                            trimHeadersLower(failedExchange.request);
+
+                            expect.errorMode = 'default';
+                            return expect(failedExchange, 'to satisfy', failedEvent.spec);
+                        } else {
+                            // ignore to cause generation of a diff
+                        }
+                    } else if (lastEventOrError === null && fulfilmentValue) {
+                        return [null, fulfilmentValue];
+                    }
+
+                    return [timeline, fulfilmentValue];
+                }).spread(function (timeline, fulfilmentValue) {
+                    // in the absence of a timeline immedistely resolve with fulfilmentValue
+                    if (timeline === null) {
+                        return fulfilmentValue;
+                    }
+
+                    var httpConversation = new messy.HttpConversation();
+                    var httpConversationSatisfySpec = { exchanges: [] };
+
+                    function recordEventForAssertion(event) {
+                        if (event.exchange) {
+                            httpConversation.exchanges.push(event.exchange);
+                        }
+                        if (event.spec) {
+                            httpConversationSatisfySpec.exchanges.push(event.spec);
+                        }
+                    }
+
+                    timeline.forEach(recordEventForAssertion);
+
+                    expect.errorMode = 'default';
+                    return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
+                        if (shouldReturnExtraInfo) {
+                            return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
+                        } else {
+                            return fulfilmentValue;
+                        }
+                    });
+                });
+            });
+    }
+};

--- a/lib/resolveExpectedRequestProperties.js
+++ b/lib/resolveExpectedRequestProperties.js
@@ -1,0 +1,58 @@
+var _ = require('underscore');
+var urlModule = require('url');
+
+function isRegExp(obj) {
+    return Object.prototype.toString.call(obj) === '[object RegExp]';
+}
+
+module.exports = function resolveExpectedRequestProperties(expectedRequestProperties) {
+    if (typeof expectedRequestProperties === 'string') {
+        expectedRequestProperties = { url: expectedRequestProperties };
+    } else if (expectedRequestProperties && typeof expectedRequestProperties === 'object') {
+        expectedRequestProperties = _.extend({}, expectedRequestProperties);
+    }
+    if (expectedRequestProperties) {
+        if (typeof expectedRequestProperties.url === 'string') {
+            var matchMethod = expectedRequestProperties.url.match(/^([A-Z]+) ([\s\S]*)$/);
+            if (matchMethod) {
+                expectedRequestProperties.method = expectedRequestProperties.method || matchMethod[1];
+                expectedRequestProperties.url = matchMethod[2];
+            }
+        }
+    } else {
+        expectedRequestProperties = {};
+    }
+    if (/^https?:\/\//.test(expectedRequestProperties.url)) {
+        var urlObj = urlModule.parse(expectedRequestProperties.url);
+        expectedRequestProperties.headers = expectedRequestProperties.headers || {};
+        if (Object.keys(expectedRequestProperties.headers).every(function (key) {
+            return key.toLowerCase() !== 'host';
+        })) {
+            expectedRequestProperties.headers.host = urlObj.host;
+        }
+        expectedRequestProperties.host = expectedRequestProperties.host || urlObj.hostname;
+        if (urlObj.port && typeof expectedRequestProperties.port === 'undefined') {
+            expectedRequestProperties.port = parseInt(urlObj.port, 10);
+        }
+
+        if (urlObj.protocol === 'https:' && typeof expectedRequestProperties.encrypted === 'undefined') {
+            expectedRequestProperties.encrypted = true;
+        }
+        expectedRequestProperties.url = urlObj.path;
+    }
+
+    var expectedRequestBody = expectedRequestProperties.body;
+    if (Array.isArray(expectedRequestBody) || (expectedRequestBody && typeof expectedRequestBody === 'object' && !isRegExp(expectedRequestBody) && (typeof Buffer === 'undefined' || !Buffer.isBuffer(expectedRequestBody)))) {
+        // in the case of a streamed request body and skip asserting the body
+        if (typeof expectedRequestBody.pipe === 'function') {
+            throw new Error('unexpected-mitm: a stream cannot be used to verify the request body, please specify the buffer instead.');
+        }
+        expectedRequestProperties.headers = expectedRequestProperties.headers || {};
+        if (Object.keys(expectedRequestProperties.headers).every(function (key) {
+            return key.toLowerCase() !== 'content-type';
+        })) {
+            expectedRequestProperties.headers['Content-Type'] = 'application/json';
+        }
+    }
+    return expectedRequestProperties;
+};

--- a/lib/trimHeadersLower.js
+++ b/lib/trimHeadersLower.js
@@ -1,0 +1,8 @@
+module.exports = function trimHeadersLower(message) {
+    delete message.headers.valuesByName['content-length'];
+    delete message.headers.valuesByName['transfer-encoding'];
+    delete message.headers.valuesByName.connection;
+    delete message.headers.valuesByName.date;
+
+    return message;
+};

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1,20 +1,21 @@
 /* global setImmediate, process, after, console */
 var messy = require('messy'),
-    createError = require('createerror'),
+    consumeReadableStream = require('./consumeReadableStream'),
     createMitm = require('mitm-papandreou'),
+    createSerializedRequestHandler = require('./createSerializedRequestHandler'),
     _ = require('underscore'),
     http = require('http'),
     https = require('https'),
+    formatHeaderObj = require('./formatHeaderObj'),
     fs = require('fs'),
     path = require('path'),
-    stream = require('stream'),
-    urlModule = require('url'),
     memoizeSync = require('memoizesync'),
     callsite = require('callsite'),
     detectIndent = require('detect-indent'),
     metadataPropertyNames = messy.HttpRequest.metadataPropertyNames.concat('rejectUnauthorized');
 
-var isNodeZeroTen = !!process.version.match(/v0.10/);
+var UnexpectedMitmMocker = require('./UnexpectedMitmMocker');
+
 // fallback to an inlined version of 0.12+ path.isAbsolute() for 0.10 compat
 var pathIsAbsolute = path.isAbsolute || function (path) {
     var len = path.length;
@@ -38,31 +39,12 @@ var pathIsAbsolute = path.isAbsolute || function (path) {
     return false;
 };
 
-// base error
-var UnexpectedMitmError = createError({ name: 'UnexpectedMitmError' });
-// marker errors
-var EarlyExitError = createError({ name: 'EarlyExitError' }, UnexpectedMitmError);
-var SawUnexpectedRequestsError = createError({ name: 'SawUnexpectedRequestsError' }, UnexpectedMitmError);
-var UnexercisedMocksError = createError({ name: 'UnexercisedMocksError' }, UnexpectedMitmError);
-
 function checkEnvFlag(varName) {
     return process.env[varName] === 'true';
 }
 
-function isRegExp(obj) {
-    return Object.prototype.toString.call(obj) === '[object RegExp]';
-}
-
 function isTextualBody(message, content) {
     return message.hasTextualContentType && bufferCanBeInterpretedAsUtf8(content);
-}
-
-function formatHeaderObj(headerObj) {
-    var result = {};
-    Object.keys(headerObj).forEach(function (headerName) {
-        result[messy.formatHeaderName(headerName)] = headerObj[headerName];
-    });
-    return result;
 }
 
 function bufferCanBeInterpretedAsUtf8(buffer) {
@@ -97,13 +79,6 @@ function trimHeaders(message) {
     delete message.headers['Transfer-Encoding'];
     delete message.headers.Connection;
     delete message.headers.Date;
-}
-
-function trimHeadersLower(message) {
-    delete message.headers.valuesByName['content-length'];
-    delete message.headers.valuesByName['transfer-encoding'];
-    delete message.headers.valuesByName.connection;
-    delete message.headers.valuesByName.date;
 }
 
 function trimMessage(message) {
@@ -153,219 +128,11 @@ function trimMessage(message) {
     return message;
 }
 
-function trimMockResponse(mockResponse) {
-    var responseProperties = {};
-    responseProperties.statusCode = mockResponse.statusCode;
-    responseProperties.statusMessage = mockResponse.statusMessage;
-    responseProperties.protocolName = mockResponse.protocolName;
-    responseProperties.protocolVersion = mockResponse.protocolVersion;
-    responseProperties.headers = formatHeaderObj(mockResponse.headers.valuesByName);
-
-    if (mockResponse.body) {
-        // read out the messy decoded body
-        responseProperties.body = mockResponse.body;
-    }
-
-    return responseProperties;
-}
-
 function trimRecordedExchange(recordedExchange) {
     return {
         request: trimMessage(recordedExchange.request),
         response: trimMessage(recordedExchange.response)
     };
-}
-
-function createSerializedRequestHandler(onRequest) {
-    var activeRequest = false,
-        requestQueue = [];
-
-    function processNextRequest() {
-        function cleanUpAndProceed() {
-            if (activeRequest) {
-                activeRequest = false;
-                setImmediate(processNextRequest);
-            }
-        }
-        while (requestQueue.length > 0 && !activeRequest) {
-            activeRequest = true;
-            var reqAndRes = requestQueue.shift(),
-                req = reqAndRes[0],
-                res = reqAndRes[1],
-                resEnd = res.end;
-            res.end = function () {
-                resEnd.apply(this, arguments);
-                cleanUpAndProceed();
-            };
-            // This happens upon an error, so we need to make sure that we catch that case also:
-            res.on('close', cleanUpAndProceed);
-            onRequest(req, res);
-        }
-    }
-
-    return function (req, res) {
-        requestQueue.push([req, res]);
-        processNextRequest();
-    };
-}
-
-function resolveExpectedRequestProperties(expectedRequestProperties) {
-    if (typeof expectedRequestProperties === 'string') {
-        expectedRequestProperties = { url: expectedRequestProperties };
-    } else if (expectedRequestProperties && typeof expectedRequestProperties === 'object') {
-        expectedRequestProperties = _.extend({}, expectedRequestProperties);
-    }
-    if (expectedRequestProperties) {
-        if (typeof expectedRequestProperties.url === 'string') {
-            var matchMethod = expectedRequestProperties.url.match(/^([A-Z]+) ([\s\S]*)$/);
-            if (matchMethod) {
-                expectedRequestProperties.method = expectedRequestProperties.method || matchMethod[1];
-                expectedRequestProperties.url = matchMethod[2];
-            }
-        }
-    } else {
-        expectedRequestProperties = {};
-    }
-    if (/^https?:\/\//.test(expectedRequestProperties.url)) {
-        var urlObj = urlModule.parse(expectedRequestProperties.url);
-        expectedRequestProperties.headers = expectedRequestProperties.headers || {};
-        if (Object.keys(expectedRequestProperties.headers).every(function (key) {
-            return key.toLowerCase() !== 'host';
-        })) {
-            expectedRequestProperties.headers.host = urlObj.host;
-        }
-        expectedRequestProperties.host = expectedRequestProperties.host || urlObj.hostname;
-        if (urlObj.port && typeof expectedRequestProperties.port === 'undefined') {
-            expectedRequestProperties.port = parseInt(urlObj.port, 10);
-        }
-
-        if (urlObj.protocol === 'https:' && typeof expectedRequestProperties.encrypted === 'undefined') {
-            expectedRequestProperties.encrypted = true;
-        }
-        expectedRequestProperties.url = urlObj.path;
-    }
-
-    var expectedRequestBody = expectedRequestProperties.body;
-    if (Array.isArray(expectedRequestBody) || (expectedRequestBody && typeof expectedRequestBody === 'object' && !isRegExp(expectedRequestBody) && (typeof Buffer === 'undefined' || !Buffer.isBuffer(expectedRequestBody)))) {
-        // in the case of a streamed request body and skip asserting the body
-        if (typeof expectedRequestBody.pipe === 'function') {
-            throw new Error('unexpected-mitm: a stream cannot be used to verify the request body, please specify the buffer instead.');
-        }
-        expectedRequestProperties.headers = expectedRequestProperties.headers || {};
-        if (Object.keys(expectedRequestProperties.headers).every(function (key) {
-            return key.toLowerCase() !== 'content-type';
-        })) {
-            expectedRequestProperties.headers['Content-Type'] = 'application/json';
-        }
-    }
-    return expectedRequestProperties;
-}
-
-function createMockResponse(responseProperties) {
-    var mockResponse = new messy.HttpResponse(responseProperties);
-    mockResponse.statusCode = mockResponse.statusCode || 200;
-    mockResponse.protocolName = mockResponse.protocolName || 'HTTP';
-    mockResponse.protocolVersion = mockResponse.protocolVersion || '1.1';
-    mockResponse.statusMessage = mockResponse.statusMessage || http.STATUS_CODES[mockResponse.statusCode];
-    return mockResponse;
-}
-
-function calculateBodyByteCount(chunk) {
-    var trailerIdx = findHeaderSeparator(chunk);
-    if (trailerIdx !== -1) {
-        return chunk.slice(trailerIdx + 4).length;
-    }
-
-    return 0;
-}
-
-function findHeaderSeparator(chunk) {
-    return chunk.toString().indexOf('\r\n\r\n');
-}
-
-function isTrailerChunk(chunk) {
-    return chunk.slice(-5).toString() === '0\r\n\r\n';
-}
-
-function attachConnectionHook(connection, callback) {
-    var bodyByteCount = 0;
-    var contentLengthByteCount = 0;
-    var hasContentLength = false;
-    var rawChunks = [];
-    var sawHeaders = false;
-    var _write = connection._write;
-
-    /*
-     * wrap low level write to gather response data and return raw data
-     * to callback when entire response is written
-     */
-    connection._write = function (chunk, encoding, cb) {
-        chunk = Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk);
-
-        rawChunks.push(chunk);
-
-        if (!sawHeaders) {
-            var chunkString = chunk.toString();
-            var match;
-
-            match = chunkString.match(/^Transfer-Encoding: /m);
-            if (match) {
-                sawHeaders = true;
-            }
-
-            match = chunkString.match(/^Content-Length: (\d+)/m);
-            if (match) {
-                // handle the current chunk containing body bytes
-                bodyByteCount = calculateBodyByteCount(chunk);
-                contentLengthByteCount = +match[1];
-                hasContentLength = true;
-                sawHeaders = true;
-            }
-        } else {
-            bodyByteCount += chunk.length;
-        }
-
-        if ((isTrailerChunk(chunk) && !hasContentLength) ||
-                (hasContentLength && bodyByteCount === contentLengthByteCount)) {
-            /*
-             * explicitly execute the callback returning raw data here
-             * to ensure it is run before issuing the final write which
-             * will complete the request on the wire
-             */
-            callback(null, Buffer.concat(rawChunks));
-        }
-
-        _write.call(connection, chunk, encoding, cb);
-    };
-}
-
-function attachResponseHooks(res, callback) {
-    var hasEnded = false; // keep track of whether res.end() has been called
-
-    attachConnectionHook(res.connection, function (err, rawBuffer) {
-        if (hasEnded) {
-            callback(null, rawBuffer);
-        }
-    });
-
-    ['end', 'destroy'].forEach(function (methodName) {
-        var orig = res[methodName];
-        res[methodName] = function (chunk, encoding) {
-            if (methodName === 'end') {
-                hasEnded = true;
-            }
-
-            var returnValue = orig.apply(this, arguments);
-
-            if (methodName === 'destroy') {
-                hasEnded = true;
-                callback(null);
-            }
-
-            // unconditionally return value given we do not wrap write
-            return returnValue;
-        };
-    });
 }
 
 function determineCallsite(stack) {
@@ -543,60 +310,6 @@ module.exports = {
             } else {
                 console.warn('unexpected-mitm: Could not find the right place to inject the recorded exchanges into ' + sourceFileName + ' (around line ' + sourceLineNumber + '): ' + stringify(recordedExchanges, indentationWidth, expect));
             }
-        }
-
-        function consumeReadableStream(readableStream, options) {
-            options = options || {};
-            var skipConcat = !!options.skipConcat;
-
-            return expect.promise(function (resolve, reject) {
-                var chunks = [];
-                readableStream.on('data', function (chunk) {
-                    chunks.push(chunk);
-                }).on('end', function (chunk) {
-                    resolve({ body: skipConcat ? chunks : Buffer.concat(chunks) });
-                }).on('error', function (err) {
-                    resolve({ body: skipConcat ? chunks : Buffer.concat(chunks), error: err });
-                });
-            });
-        }
-
-        function getMockResponse(responseProperties) {
-            var mockResponse;
-            var mockResponseError;
-            if (Object.prototype.toString.call(responseProperties) === '[object Error]') {
-                mockResponseError = responseProperties;
-            } else {
-                mockResponse = createMockResponse(responseProperties);
-            }
-
-            return expect.promise(function () {
-                if (!mockResponseError && mockResponse && mockResponse.body && typeof mockResponse.body.pipe === 'function') {
-                    return consumeReadableStream(mockResponse.body).then(function (result) {
-                        if (result.error) {
-                            mockResponseError = result.error;
-                        }
-                        if (result.body) {
-                            mockResponse.unchunkedBody = result.body;
-                        }
-                    });
-                }
-            }).then(function () {
-                if (mockResponse && !mockResponseError && (Array.isArray(mockResponse.body) || (mockResponse.body && typeof mockResponse.body === 'object' && (typeof Buffer === 'undefined' || !Buffer.isBuffer(mockResponse.body))))) {
-                    if (!mockResponse.headers.has('Content-Type')) {
-                        mockResponse.headers.set('Content-Type', 'application/json');
-                    }
-                }
-                return [ mockResponse, mockResponseError ];
-            });
-        }
-
-        function observeResponse(res) {
-            return expect.promise(function (resolve, reject) {
-                attachResponseHooks(res, function (err, rawBuffer) {
-                    resolve(rawBuffer);
-                });
-            });
         }
 
         function performRequest(requestResult) {
@@ -889,11 +602,14 @@ module.exports = {
                     return verifyBlock;
                 });
 
-                var assertionPromise = modules.Mocker({
-                    descriptions: requestDescriptions,
-                    consume: function () {
-                        return expect.shift();
-                    }
+                var mocker = new UnexpectedMitmMocker({
+                    descriptions: requestDescriptions
+                });
+
+                var assertionPromise = mocker.mock(function () {
+                    return expect.shift();
+                }).then(function (result) {
+                    return [result.timeline, result.fulfilmentValue];
                 }).spread(function (timeline, fulfilmentValue) {
                     var lastEventOrError = null;
 
@@ -970,309 +686,5 @@ module.exports = {
 
                 return assertionPromise;
             });
-
-        var modules = {
-            Mocker: function (options) {
-                options = options || {};
-                var requestDescriptions = options.descriptions;
-                var consumptionPromise = options.consume;
-
-                var mitm = createMitm();
-
-                // Keep track of the current requestDescription
-                var nextRequestDescriptionIndex = 0;
-
-                // Keep track of the http/https agents that we have seen
-                // during the test so we can clean up afterwards:
-                var seenAgents = [];
-
-                // accumulator for events
-                var timeline = [];
-
-                return expect.promise(function (resolve, reject) {
-                    mitm.on('request', createSerializedRequestHandler(function (req, res) {
-                        if (!res.connection) {
-                            // I've observed some cases where keep-alive is
-                            // being used and we end up with an extra "phantom
-                            // request event" even though only requeest is being
-                            // issued. Seems like a bug in mitm.
-                            // It goes without saying that we should try to get
-                            // rid of this. Hopefully something will happen
-                            // on https://github.com/moll/node-mitm/pull/36
-                            return;
-                        }
-                        var clientSocket = req.connection._mitm.client;
-                        var clientSocketOptions = req.connection._mitm.opts;
-                        if (typeof clientSocketOptions.port === 'string') {
-                            // The port could have been defined as a string in a 3rdparty library doing the http(s) call, and that seems to be valid use of the http(s) module
-                            clientSocketOptions = _.defaults({
-                                port: parseInt(clientSocketOptions.port, 10)
-                            }, clientSocketOptions);
-                        }
-                        var agent = clientSocketOptions.agent || (res.connection.encrypted ? https : http).globalAgent;
-                        if (seenAgents.indexOf(agent) === -1) {
-                            seenAgents.push(agent);
-                        }
-                        var currentDescription = requestDescriptions[nextRequestDescriptionIndex];
-                        nextRequestDescriptionIndex += 1;
-                        var hasRequestDescription = !!currentDescription,
-                            metadata =
-                                _.defaults(
-                                    { encrypted: Boolean(res.connection.encrypted) },
-                                    _.pick(clientSocketOptions, messy.HttpRequest.metadataPropertyNames),
-                                    _.pick(clientSocketOptions && clientSocketOptions.agent && clientSocketOptions.agent.options, messy.HttpRequest.metadataPropertyNames)
-                                ),
-                            requestDescription = currentDescription,
-                            requestProperties,
-                            responseProperties = requestDescription && requestDescription.response,
-                            expectedRequestProperties;
-
-                        expect.promise(function () {
-                            expectedRequestProperties = resolveExpectedRequestProperties(requestDescription && requestDescription.request);
-                        }).then(function () {
-                            return consumeReadableStream(req, {skipConcat: true});
-                        }).then(function (result) {
-                            if (result.error) {
-                                // TODO: Consider adding support for recording this (the request erroring out while we're consuming it)
-                                throw result.error;
-                            }
-                            requestProperties = _.extend({
-                                method: req.method,
-                                path: req.url,
-                                protocolName: 'HTTP',
-                                protocolVersion: req.httpVersion,
-                                headers: req.headers,
-                                unchunkedBody: Buffer.concat(result.body)
-                            }, metadata);
-
-                            if (!hasRequestDescription) {
-                                // there was no mock so arrange "<no response>"
-                                assertMockResponse(null);
-
-                                /*
-                                 * We wish to cause the generation of a diff
-                                 * so we arrange to enter our 'success' path
-                                 * but ensure the delegated assertion fully
-                                 * completes by signalling an error condition.
-                                 *
-                                 * Note the use of the single reject/resolve
-                                 * behaviour of promises: while the delegated
-                                 * assertion is reject()ed, we have already
-                                 * resolve()d thus the rejection of the former
-                                 * is effectively ignored and we proceed with
-                                 * our output.
-                                 */
-
-                                // cancel the delegated assertion
-                                throw new SawUnexpectedRequestsError('unexpected-mitm: Saw unexpected requests.');
-                            }
-
-                            if (typeof responseProperties === 'function') {
-                                // reset the readable req stream state
-                                stream.Readable.call(req);
-
-                                // read stream data from the buffered chunks
-                                req._read = function () {
-                                    this.push(result.body.shift() || null);
-                                };
-
-                                if (isNodeZeroTen) {
-                                    /*
-                                     * As is mentioned in the streams documentation this
-                                     * call can be issued to kick some of the machinery
-                                     * and is apparently done within the standard lib.
-                                     */
-                                    req.read(0);
-                                }
-
-                                // call response function inside a promise to catch exceptions
-                                return expect.promise(function () {
-                                    responseProperties(req, res);
-                                }).then(function () {
-                                    return [null, null];
-                                }).caught(function (err) {
-                                    // ensure delivery of the caught error to the underlying socket
-                                    return [null, err];
-                                });
-                            } else {
-                                return getMockResponse(responseProperties);
-                            }
-                        }).spread(function (mockResponse, mockResponseError) {
-                            if (!(mockResponse || mockResponseError)) {
-                                return;
-                            }
-
-                            var originalErrorMode = expect.errorMode;
-                            expect.errorMode = 'default';
-                            return expect.promise(function () {
-                                var assertionMockRequest = new messy.HttpRequest(requestProperties);
-                                trimHeadersLower(assertionMockRequest);
-                                return expect(assertionMockRequest, 'to satisfy', expectedRequestProperties);
-                            }).then(function () {
-                                expect.errorMode = originalErrorMode;
-                                // continue thus respond
-                                deliverMockResponse(mockResponse, mockResponseError);
-                            }).catch(function (e) {
-                                assertMockResponse(mockResponse, mockResponseError);
-                                throw new EarlyExitError('Seen request did not match the expected request.');
-                            });
-                        }).caught(function (e) {
-                            /*
-                             * Given an error occurs, the deferred assertion
-                             * will still be pending and must be completed. We
-                             * do this by signalling the error on the socket.
-                             */
-
-                            // cancel the delegated assertion
-                            try {
-                                clientSocket.emit('error', e);
-                            } finally {
-                                /*
-                                 * If an something was thrown trying to signal
-                                 * an error we have little choice but to try to
-                                 * reject the assertion. This is only safe with
-                                 * Unexpected 10.15.x and above.
-                                 */
-
-                                timeline.push(e);
-                                reject(e);
-                            }
-                        });
-
-                        function assertMockResponse(mockResponse, mockResponseError) {
-                            var mockRequest = new messy.HttpRequest(requestProperties);
-
-                            var httpExchange = new messy.HttpExchange({request: mockRequest});
-                            if (mockResponse) {
-                                httpExchange.response = mockResponse;
-                            } else if (mockResponseError) {
-                                httpExchange.response = mockResponseError;
-                            }
-
-                            var eventSpec = null;
-                            // only attempt request validation with a mock
-                            if (hasRequestDescription) {
-                                eventSpec = {request: expectedRequestProperties};
-                            }
-
-                            /*
-                             * We explicitly do not complete the promise
-                             * when the last request for which we have a
-                             * mock is seen.
-                             *
-                             * Instead simply record any exchanges that
-                             * passed through and defer the resolution or
-                             * rejection to the handler functions attached
-                             * to the delegated assertion execution below.
-                             */
-
-                            timeline.push({
-                                exchange: httpExchange,
-                                spec: eventSpec
-                            });
-                        }
-
-                        function deliverMockResponse(mockResponse, mockResponseError) {
-                            setImmediate(function () {
-                                var nonEmptyMockResponse = false;
-                                if (mockResponse) {
-                                    res.statusCode = mockResponse.statusCode;
-                                    mockResponse.headers.getNames().forEach(function (headerName) {
-                                        mockResponse.headers.getAll(headerName).forEach(function (value) {
-                                            nonEmptyMockResponse = true;
-                                            res.setHeader(headerName, value);
-                                        });
-                                    });
-                                    var unchunkedBody = mockResponse.unchunkedBody;
-                                    if (typeof unchunkedBody !== 'undefined' && unchunkedBody.length > 0) {
-                                        nonEmptyMockResponse = true;
-                                        res.write(unchunkedBody);
-                                    } else if (nonEmptyMockResponse) {
-                                        res.writeHead(res.statusCode || 200);
-                                    }
-                                }
-                                if (mockResponseError) {
-                                    setImmediate(function () {
-                                        clientSocket.emit('error', mockResponseError);
-                                        assertMockResponse(mockResponse, mockResponseError);
-                                    });
-                                } else {
-                                    res.end();
-                                }
-                            });
-                        }
-
-                        /*
-                         * hook final write callback to record raw data and immediately
-                         * assert request so it occurs prior to request completion
-                         */
-                        observeResponse(res).then(function (rawBuffer) {
-                            var mockResponse = createMockResponse(rawBuffer);
-                            assertMockResponse(mockResponse);
-                        });
-                    }));
-
-                    expect.promise(function () {
-                        return consumptionPromise();
-                    }).then(function (fulfilmentValue) {
-                        /*
-                         * Handle the case of specified but unprocessed mocks.
-                         * If there were none remaining immediately complete.
-                         *
-                         * Where the driving assertion resolves we must check
-                         * if any mocks still exist. If so, we add them to the
-                         * set of expected exchanges and resolve the promise.
-                         */
-                        var hasRemainingRequestDescriptions = nextRequestDescriptionIndex < requestDescriptions.length;
-                        if (hasRemainingRequestDescriptions) {
-                            // exhaust remaining mocks using a promises chain
-                            return (function nextItem() {
-                                var remainingDescription = requestDescriptions[nextRequestDescriptionIndex];
-                                nextRequestDescriptionIndex += 1;
-                                if (remainingDescription) {
-                                    var expectedRequestProperties;
-
-                                    return expect.promise(function () {
-                                        expectedRequestProperties = resolveExpectedRequestProperties(remainingDescription.request);
-                                    }).then(function () {
-                                        return getMockResponse(remainingDescription.response);
-                                    }).spread(function (mockResponse, mockResponseError) {
-                                        var spec = {
-                                            request: expectedRequestProperties,
-                                            response: mockResponseError || trimMockResponse(mockResponse)
-                                        };
-
-                                        timeline.push({ spec: spec });
-
-                                        return nextItem();
-                                    });
-                                } else {
-                                    throw new UnexercisedMocksError();
-                                }
-                            })();
-                        } else {
-                            resolve([fulfilmentValue]);
-                        }
-                    }).caught(function (e) {
-                        timeline.push(e);
-                        reject(e);
-                    });
-                }).spread(function (fulfilmentValue) {
-                    return [timeline, fulfilmentValue];
-                }).catch(function () {
-                    // given we will later fail on "to satisfy" pass a null fulfilment value
-                    return [timeline, null];
-                }).finally(function () {
-                    seenAgents.forEach(function (agent) {
-                        if (agent.freeSockets) {
-                            Object.keys(agent.freeSockets).forEach(function (key) {
-                                agent.freeSockets[key] = [];
-                            });
-                        }
-                    });
-                    mitm.disable();
-                });
-            }
-        };
     }
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -901,6 +901,14 @@ module.exports = {
                         var name = lastEventOrError.name;
                         if (name === 'Error' || name === 'UnexpectedError') {
                             throw lastEventOrError;
+                        } else if (name === 'EarlyExitError') {
+                            // in the case of an early exirt error we need
+                            // to generate a diff from the last recorded
+                            // event & spec
+                            var failedRequestEvent = timeline[timeline.length - 2];
+
+                            expect.errorMode = 'default';
+                            expect(failedRequestEvent.exchange, 'to satisfy', failedRequestEvent.spec);
                         } else {
                             // ignore to cause generation of a diff
                         }

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -321,7 +321,7 @@ module.exports = {
                     port: requestResult.port,
                     path: requestResult.path
                 }, requestResult.metadata)).on('response', function (response) {
-                    consumeReadableStream(response).caught(reject).then(function (result) {
+                    consumeReadableStream(response).catch(reject).then(function (result) {
                         if (result.error) {
                             // TODO: Consider adding support for recording this (the upstream response erroring out while we're recording it)
                             return reject(result.error);
@@ -434,7 +434,7 @@ module.exports = {
                             response: {}
                         };
                     recordedExchanges.push(recordedExchange);
-                    consumeReadableStream(req).caught(reject).then(function (result) {
+                    consumeReadableStream(req).catch(reject).then(function (result) {
                         if (result.error) {
                             // TODO: Consider adding support for recording this (the request erroring out while we're recording it)
                             return reject(result.error);
@@ -480,7 +480,7 @@ module.exports = {
                                 });
                                 res.end(recordedExchange.response.body);
                             });
-                        }).caught(function (err) {
+                        }).catch(function (err) {
                             recordedExchange.response = err;
                             clientSocket.emit('error', err);
                         });
@@ -489,7 +489,7 @@ module.exports = {
 
                 expect.promise(function () {
                     return expect.shift();
-                }).caught(reject).then(function (value) {
+                }).catch(reject).then(function (value) {
                     recordedExchanges = recordedExchanges.map(trimRecordedExchange);
                     if (recordedExchanges.length === 1) {
                         recordedExchanges = recordedExchanges[0];
@@ -606,8 +606,10 @@ module.exports = {
                     descriptions: requestDescriptions
                 });
 
-                var assertionPromise = mocker.mock(function () {
-                    return expect.shift();
+                var assertionPromise = expect.promise(function () {
+                    return mocker.mock(function () {
+                        return expect.shift();
+                    });
                 }).then(function (result) {
                     return [result.timeline, result.fulfilmentValue];
                 }).spread(function (timeline, fulfilmentValue) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -580,9 +580,10 @@ module.exports = {
                 });
             })
             .exportAssertion('<any> with http mocked out [and verified] [with extra info] [allowing modification] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
-                expect.errorMode = 'nested';
+                expect.errorMode = 'default';
                 var shouldBeVerified = checkEnvFlag('UNEXPECTED_MITM_VERIFY') || expect.flags['and verified'];
-                var shouldReturnExtraInfo = expect.flags['with extra info'];
+                var shouldReturnExtraInfo = expect.flags['with extra info'] || shouldBeVerified;
+                expect.flags['with extra info'] = shouldReturnExtraInfo;
 
                 if (!Array.isArray(requestDescriptions)) {
                     if (typeof requestDescriptions === 'undefined') {
@@ -610,6 +611,38 @@ module.exports = {
                     return mocker.mock(function () {
                         return expect.shift();
                     });
+                }).then(function () {
+                    return expect(mocker, 'to be complete [with extra info]');
+                });
+
+                if (shouldBeVerified) {
+                    var verifier = createVerifier(expect, verifyBlocks);
+
+                    return assertionPromise.spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
+                        return verifier(fulfilmentValue, httpConversation, httpConversationSatisfySpec).then(function () {
+                            if (shouldReturnExtraInfo) {
+                                return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
+                            } else {
+                                return fulfilmentValue;
+                            }
+                        });
+                    });
+                }
+
+                return assertionPromise;
+            })
+            .exportType({
+                name: 'UnexpectedMitmMocker',
+                base: 'object',
+                identify: function (obj) {
+                    return obj instanceof UnexpectedMitmMocker;
+                }
+            })
+            .exportAssertion('<UnexpectedMitmMocker> to be complete [with extra info]', function (expect, subject) {
+                var shouldReturnExtraInfo = expect.flags['with extra info'];
+
+                return expect.promise(function () {
+                    return subject;
                 }).then(function (result) {
                     return [result.timeline, result.fulfilmentValue];
                 }).spread(function (timeline, fulfilmentValue) {
@@ -662,31 +695,13 @@ module.exports = {
 
                     expect.errorMode = 'default';
                     return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
-                        if (shouldBeVerified || shouldReturnExtraInfo) {
+                        if (shouldReturnExtraInfo) {
                             return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
                         } else {
                             return fulfilmentValue;
                         }
                     });
                 });
-
-                if (shouldBeVerified) {
-                    expect.errorMode = 'default';
-
-                    var verifier = createVerifier(expect, verifyBlocks);
-
-                    return assertionPromise.spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
-                        return verifier(fulfilmentValue, httpConversation, httpConversationSatisfySpec).then(function () {
-                            if (shouldReturnExtraInfo) {
-                                return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
-                            } else {
-                                return fulfilmentValue;
-                            }
-                        });
-                    });
-                }
-
-                return assertionPromise;
             });
     }
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -883,18 +883,21 @@ module.exports = {
                     requestDescriptions = requestDescriptions.slice(0);
 
                 }
-                var nextRequestDescriptionIndex = 0;
 
-                var exchangeParts = [];
                 var verifyBlocks = requestDescriptions.map(function (description) {
                     var verifyBlock = description.verify || {};
                     delete description.verify;
                     return verifyBlock;
                 });
+                // Keep track of the current requestDescription
+                var nextRequestDescriptionIndex = 0;
 
                 // Keep track of the http/https agents that we have seen
                 // during the test so we can clean up afterwards:
                 var seenAgents = [];
+
+                // accumulator for events
+                var timeline = [];
 
                 var assertionPromise = expect.promise(function (resolve, reject) {
                     mitm.on('request', createSerializedRequestHandler(function (req, res) {
@@ -1041,17 +1044,13 @@ module.exports = {
                                  * Unexpected 10.15.x and above.
                                  */
 
-                                exchangeParts.push(e);
+                                timeline.push(e);
                                 reject(e);
                             }
                         });
 
                         function assertMockResponse(mockResponse, mockResponseError) {
                             var mockRequest = new messy.HttpRequest(requestProperties);
-                            var httpPart = {
-                                exchange: undefined,
-                                spec: undefined
-                            };
 
                             var httpExchange = new messy.HttpExchange({request: mockRequest});
                             if (mockResponse) {
@@ -1059,11 +1058,11 @@ module.exports = {
                             } else if (mockResponseError) {
                                 httpExchange.response = mockResponseError;
                             }
-                            httpPart.exchange = httpExchange;
 
+                            var eventSpec = null;
                             // only attempt request validation with a mock
                             if (hasRequestDescription) {
-                                httpPart.spec = {request: expectedRequestProperties};
+                                eventSpec = {request: expectedRequestProperties};
                             }
 
                             /*
@@ -1077,7 +1076,10 @@ module.exports = {
                              * to the delegated assertion execution below.
                              */
 
-                            exchangeParts.push(httpPart);
+                            timeline.push({
+                                exchange: httpExchange,
+                                spec: eventSpec
+                            });
                         }
 
                         function deliverMockResponse(mockResponse, mockResponseError) {
@@ -1150,7 +1152,7 @@ module.exports = {
                                             response: mockResponseError || trimMockResponse(mockResponse)
                                         };
 
-                                        exchangeParts.push({ spec: spec });
+                                        timeline.push({ spec: spec });
 
                                         return nextItem();
                                     });
@@ -1162,16 +1164,16 @@ module.exports = {
                             resolve([fulfilmentValue]);
                         }
                     }).caught(function (e) {
-                        exchangeParts.push(e);
+                        timeline.push(e);
                         reject(e);
                     });
                 }).catch(function () {
-                    var lastPartOrError = exchangeParts[exchangeParts.length - 1];
+                    var lastEventOrError = timeline[timeline.length - 1];
 
-                    if (lastPartOrError instanceof Error) {
-                        var name = lastPartOrError.name;
+                    if (lastEventOrError instanceof Error) {
+                        var name = lastEventOrError.name;
                         if (name === 'Error' || name === 'UnexpectedError') {
-                            throw lastPartOrError;
+                            throw lastEventOrError;
                         } else {
                             // ignore to cause generation of a diff
                         }
@@ -1183,16 +1185,16 @@ module.exports = {
                     var httpConversation = new messy.HttpConversation();
                     var httpConversationSatisfySpec = { exchanges: [] };
 
-                    function recordPartForAssertion(part) {
-                        if (part.exchange) {
-                            httpConversation.exchanges.push(part.exchange);
+                    function recordEventForAssertion(event) {
+                        if (event.exchange) {
+                            httpConversation.exchanges.push(event.exchange);
                         }
-                        if (part.spec) {
-                            httpConversationSatisfySpec.exchanges.push(part.spec);
+                        if (event.spec) {
+                            httpConversationSatisfySpec.exchanges.push(event.spec);
                         }
                     }
 
-                    exchangeParts.forEach(recordPartForAssertion);
+                    timeline.forEach(recordEventForAssertion);
 
                     expect.errorMode = 'default';
                     return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -9,6 +9,7 @@ var messy = require('messy'),
     formatHeaderObj = require('./formatHeaderObj'),
     fs = require('fs'),
     path = require('path'),
+    trimHeadersLower = require('./trimHeadersLower'),
     memoizeSync = require('memoizesync'),
     callsite = require('callsite'),
     detectIndent = require('detect-indent'),
@@ -661,10 +662,12 @@ module.exports = {
                             // in the case of an early exirt error we need
                             // to generate a diff from the last recorded
                             // event & spec
-                            var failedRequestEvent = timeline[timeline.length - 2];
+                            var failedEvent = timeline[timeline.length - 2];
+                            var failedExchange = failedEvent.exchange;
+                            trimHeadersLower(failedExchange.request);
 
                             expect.errorMode = 'default';
-                            expect(failedRequestEvent.exchange, 'to satisfy', failedRequestEvent.spec);
+                            return expect(failedExchange, 'to satisfy', failedEvent.spec);
                         } else {
                             // ignore to cause generation of a diff
                         }

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -605,7 +605,7 @@ module.exports = {
                 });
 
                 var mocker = new UnexpectedMitmMocker({
-                    descriptions: requestDescriptions
+                    requestDescriptions: requestDescriptions
                 });
 
                 var assertionPromise = expect.promise(function () {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -921,8 +921,7 @@ module.exports = {
                         return [null, fulfilmentValue];
                     }
 
-                    // given we later fail on "to satisfy" we pass a null fulfilment value
-                    return [timeline, null];
+                    return [timeline, fulfilmentValue];
                 }).spread(function (timeline, fulfilmentValue) {
                     // in the absence of a timeline immedistely resolve with fulfilmentValue
                     if (timeline === null) {
@@ -1261,6 +1260,7 @@ module.exports = {
                 }).spread(function (fulfilmentValue) {
                     return [timeline, fulfilmentValue];
                 }).catch(function () {
+                    // given we will later fail on "to satisfy" pass a null fulfilment value
                     return [timeline, null];
                 }).finally(function () {
                     seenAgents.forEach(function (agent) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -8,6 +8,7 @@ var messy = require('messy'),
     path = require('path'),
     stream = require('stream'),
     urlModule = require('url'),
+    util = require('util'),
     memoizeSync = require('memoizesync'),
     callsite = require('callsite'),
     detectIndent = require('detect-indent'),
@@ -36,6 +37,13 @@ var pathIsAbsolute = path.isAbsolute || function (path) {
     }
     return false;
 };
+
+function EarlyExitError(message) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+};
+util.inherits(EarlyExitError, Error);
 
 function checkEnvFlag(varName) {
     return process.env[varName] === 'true';
@@ -1017,17 +1025,14 @@ module.exports = {
                             return expect.promise(function () {
                                 var assertionMockRequest = new messy.HttpRequest(requestProperties);
                                 trimHeadersLower(assertionMockRequest);
-                                var assertionExchange = new messy.HttpExchange({request: assertionMockRequest});
-                                if (mockResponse) {
-                                    assertionExchange.response = mockResponse;
-                                } else if (mockResponseError) {
-                                    assertionExchange.response = mockResponseError;
-                                }
-                                return expect(assertionExchange, 'to satisfy', {request: expectedRequestProperties});
+                                return expect(assertionMockRequest, 'to satisfy', expectedRequestProperties);
                             }).then(function () {
                                 expect.errorMode = originalErrorMode;
                                 // continue thus respond
                                 deliverMockResponse(mockResponse, mockResponseError);
+                            }).catch(function (e) {
+                                assertMockResponse(mockResponse, mockResponseError);
+                                throw new EarlyExitError('Seen request did not match the expected request.');
                             });
                         }).caught(function (e) {
                             /*
@@ -1048,7 +1053,11 @@ module.exports = {
                                  * reject the assertion. This is only safe with
                                  * Unexpected 10.15.x and above.
                                  */
-                                reject(e);
+                                if (e.name === 'EarlyExitError') {
+                                    resolve([null, httpConversation, httpConversationSatisfySpec]);
+                                } else {
+                                    reject(e);
+                                }
                             }
                         });
 

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -974,8 +974,6 @@ module.exports = {
                                  * so we arrange to enter our 'success' path
                                  * but ensure the delegated assertion fully
                                  * completes by signalling an error condition.
-                                 * Given we later fail on "to satisfy" we pass
-                                 * a null fulfilment value.
                                  *
                                  * Note the use of the single reject/resolve
                                  * behaviour of promises: while the delegated
@@ -1180,6 +1178,20 @@ module.exports = {
                         exchangeParts.push(e);
                         reject(e);
                     });
+                }).catch(function () {
+                    var lastPartOrError = exchangeParts[exchangeParts.length - 1];
+
+                    if (lastPartOrError instanceof Error) {
+                        var name = lastPartOrError.name;
+                        if (name === 'Error' || name === 'UnexpectedError') {
+                            throw lastPartOrError;
+                        } else {
+                            // ignore to cause generation of a diff
+                        }
+                    }
+
+                    // given we later fail on "to satisfy" we pass a null fulfilment value
+                    return [null];
                 }).spread(function (fulfilmentValue) {
                     var httpConversation = new messy.HttpConversation();
                     var httpConversationSatisfySpec = { exchanges: [] };
@@ -1203,36 +1215,6 @@ module.exports = {
                             return fulfilmentValue;
                         }
                     });
-                }).catch(function (e) {
-                    var httpConversation = new messy.HttpConversation();
-                    var httpConversationSatisfySpec = { exchanges: [] };
-
-                    function recordPartForAssertion(part) {
-                        if (part.exchange) {
-                            httpConversation.exchanges.push(part.exchange);
-                        }
-                        if (part.spec) {
-                            httpConversationSatisfySpec.exchanges.push(part.spec);
-                        }
-                    }
-
-                    var lastPartOrError = exchangeParts.pop();
-
-                    exchangeParts.forEach(recordPartForAssertion);
-
-                    if (lastPartOrError instanceof Error) {
-                        var name = lastPartOrError.name;
-                        if (name === 'Error' || name === 'UnexpectedError') {
-                            throw lastPartOrError;
-                        } else {
-                            // will be caught by the assertion
-                        }
-                    } else if (lastPartOrError) {
-                        recordPartForAssertion(lastPartOrError);
-                    }
-
-                    expect.errorMode = 'default';
-                    return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec);
                 }).finally(function () {
                     seenAgents.forEach(function (agent) {
                         if (agent.freeSockets) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -894,7 +894,7 @@ module.exports = {
                     consume: function () {
                         return expect.shift();
                     }
-                }).then(function (timeline) {
+                }).spread(function (timeline, fulfilmentValue) {
                     var lastEventOrError = null;
 
                     // pull out the last event if it exists
@@ -917,11 +917,18 @@ module.exports = {
                         } else {
                             // ignore to cause generation of a diff
                         }
+                    } else if (lastEventOrError === null && fulfilmentValue) {
+                        return [null, fulfilmentValue];
                     }
 
                     // given we later fail on "to satisfy" we pass a null fulfilment value
                     return [timeline, null];
                 }).spread(function (timeline, fulfilmentValue) {
+                    // in the absence of a timeline immedistely resolve with fulfilmentValue
+                    if (timeline === null) {
+                        return fulfilmentValue;
+                    }
+
                     var httpConversation = new messy.HttpConversation();
                     var httpConversationSatisfySpec = { exchanges: [] };
 
@@ -1251,10 +1258,10 @@ module.exports = {
                         timeline.push(e);
                         reject(e);
                     });
+                }).spread(function (fulfilmentValue) {
+                    return [timeline, fulfilmentValue];
                 }).catch(function () {
-                    return timeline;
-                }).then(function () {
-                    return timeline;
+                    return [timeline, null];
                 }).finally(function () {
                     seenAgents.forEach(function (agent) {
                         if (agent.freeSockets) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -868,7 +868,6 @@ module.exports = {
             })
             .exportAssertion('<any> with http mocked out [and verified] [with extra info] [allowing modification] <array|object> <assertion>', function (expect, subject, requestDescriptions) { // ...
                 expect.errorMode = 'nested';
-                var mitm = createMitm();
                 var shouldBeVerified = checkEnvFlag('UNEXPECTED_MITM_VERIFY') || expect.flags['and verified'];
                 var shouldReturnExtraInfo = expect.flags['with extra info'];
 
@@ -889,6 +888,78 @@ module.exports = {
                     delete description.verify;
                     return verifyBlock;
                 });
+
+                var assertionPromise = modules.Mocker({
+                    descriptions: requestDescriptions,
+                    consume: function () {
+                        return expect.shift();
+                    }
+                }).then(function (timeline) {
+                    var lastEventOrError = timeline[timeline.length - 1];
+
+                    if (lastEventOrError instanceof Error) {
+                        var name = lastEventOrError.name;
+                        if (name === 'Error' || name === 'UnexpectedError') {
+                            throw lastEventOrError;
+                        } else {
+                            // ignore to cause generation of a diff
+                        }
+                    }
+
+                    // given we later fail on "to satisfy" we pass a null fulfilment value
+                    return [timeline, null];
+                }).spread(function (timeline, fulfilmentValue) {
+                    var httpConversation = new messy.HttpConversation();
+                    var httpConversationSatisfySpec = { exchanges: [] };
+
+                    function recordEventForAssertion(event) {
+                        if (event.exchange) {
+                            httpConversation.exchanges.push(event.exchange);
+                        }
+                        if (event.spec) {
+                            httpConversationSatisfySpec.exchanges.push(event.spec);
+                        }
+                    }
+
+                    timeline.forEach(recordEventForAssertion);
+
+                    expect.errorMode = 'default';
+                    return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
+                        if (shouldBeVerified || shouldReturnExtraInfo) {
+                            return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
+                        } else {
+                            return fulfilmentValue;
+                        }
+                    });
+                });
+
+                if (shouldBeVerified) {
+                    expect.errorMode = 'default';
+
+                    var verifier = createVerifier(expect, verifyBlocks);
+
+                    return assertionPromise.spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
+                        return verifier(fulfilmentValue, httpConversation, httpConversationSatisfySpec).then(function () {
+                            if (shouldReturnExtraInfo) {
+                                return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
+                            } else {
+                                return fulfilmentValue;
+                            }
+                        });
+                    });
+                }
+
+                return assertionPromise;
+            });
+
+        var modules = {
+            Mocker: function (options) {
+                options = options || {};
+                var requestDescriptions = options.descriptions;
+                var consumptionPromise = options.consume;
+
+                var mitm = createMitm();
+
                 // Keep track of the current requestDescription
                 var nextRequestDescriptionIndex = 0;
 
@@ -899,7 +970,7 @@ module.exports = {
                 // accumulator for events
                 var timeline = [];
 
-                var assertionPromise = expect.promise(function (resolve, reject) {
+                return expect.promise(function (resolve, reject) {
                     mitm.on('request', createSerializedRequestHandler(function (req, res) {
                         if (!res.connection) {
                             // I've observed some cases where keep-alive is
@@ -1123,7 +1194,7 @@ module.exports = {
                     }));
 
                     expect.promise(function () {
-                        return expect.shift();
+                        return consumptionPromise();
                     }).then(function (fulfilmentValue) {
                         /*
                          * Handle the case of specified but unprocessed mocks.
@@ -1168,42 +1239,9 @@ module.exports = {
                         reject(e);
                     });
                 }).catch(function () {
-                    var lastEventOrError = timeline[timeline.length - 1];
-
-                    if (lastEventOrError instanceof Error) {
-                        var name = lastEventOrError.name;
-                        if (name === 'Error' || name === 'UnexpectedError') {
-                            throw lastEventOrError;
-                        } else {
-                            // ignore to cause generation of a diff
-                        }
-                    }
-
-                    // given we later fail on "to satisfy" we pass a null fulfilment value
-                    return [null];
-                }).spread(function (fulfilmentValue) {
-                    var httpConversation = new messy.HttpConversation();
-                    var httpConversationSatisfySpec = { exchanges: [] };
-
-                    function recordEventForAssertion(event) {
-                        if (event.exchange) {
-                            httpConversation.exchanges.push(event.exchange);
-                        }
-                        if (event.spec) {
-                            httpConversationSatisfySpec.exchanges.push(event.spec);
-                        }
-                    }
-
-                    timeline.forEach(recordEventForAssertion);
-
-                    expect.errorMode = 'default';
-                    return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
-                        if (shouldBeVerified || shouldReturnExtraInfo) {
-                            return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
-                        } else {
-                            return fulfilmentValue;
-                        }
-                    });
+                    return timeline;
+                }).then(function () {
+                    return timeline;
                 }).finally(function () {
                     seenAgents.forEach(function (agent) {
                         if (agent.freeSockets) {
@@ -1214,24 +1252,7 @@ module.exports = {
                     });
                     mitm.disable();
                 });
-
-                if (shouldBeVerified) {
-                    expect.errorMode = 'default';
-
-                    var verifier = createVerifier(expect, verifyBlocks);
-
-                    return assertionPromise.spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
-                        return verifier(fulfilmentValue, httpConversation, httpConversationSatisfySpec).then(function () {
-                            if (shouldReturnExtraInfo) {
-                                return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
-                            } else {
-                                return fulfilmentValue;
-                            }
-                        });
-                    });
-                }
-
-                return assertionPromise;
-            });
+            }
+        };
     }
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1238,10 +1238,10 @@ module.exports = {
 
                     if (lastPartOrError instanceof Error) {
                         var name = lastPartOrError.name;
-                        if (name === 'EarlyExitError' || name === 'UnexercisedMocksError') {
-                            // will be caught by the assertion
-                        } else {
+                        if (name === 'Error' || name === 'UnexpectedError') {
                             throw lastPartOrError;
+                        } else {
+                            // will be caught by the assertion
                         }
                     } else if (lastPartOrError) {
                         recordPartForAssertion(lastPartOrError);

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1161,7 +1161,7 @@ module.exports = {
                         var hasRemainingRequestDescriptions = nextRequestDescriptionIndex < requestDescriptions.length;
                         if (hasRemainingRequestDescriptions) {
                             // exhaust remaining mocks using a promises chain
-                            (function nextItem() {
+                            return (function nextItem() {
                                 var remainingDescription = requestDescriptions[nextRequestDescriptionIndex];
                                 nextRequestDescriptionIndex += 1;
                                 if (remainingDescription) {
@@ -1180,7 +1180,7 @@ module.exports = {
                                         exchangeParts.push({ spec: spec });
 
                                         return nextItem();
-                                    }).caught(reject);
+                                    });
                                 } else {
                                     throw new UnexercisedMocksError();
                                 }
@@ -1192,10 +1192,25 @@ module.exports = {
                         if (__lastError) {
                             reject(__lastError);
                         } else {
+                            exchangeParts.push(e);
                             reject(e);
                         }
                     });
-                }).spread(function (fulfilmentValue, httpConversation, httpConversationSatisfySpec) {
+                }).spread(function (fulfilmentValue) {
+                    var httpConversation = new messy.HttpConversation();
+                    var httpConversationSatisfySpec = { exchanges: [] };
+
+                    function recordPartForAssertion(part) {
+                        if (part.exchange) {
+                            httpConversation.exchanges.push(part.exchange);
+                        }
+                        if (part.spec) {
+                            httpConversationSatisfySpec.exchanges.push(part.spec);
+                        }
+                    }
+
+                    exchangeParts.forEach(recordPartForAssertion);
+
                     expect.errorMode = 'default';
                     return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
                         if (shouldBeVerified || shouldReturnExtraInfo) {
@@ -1232,7 +1247,8 @@ module.exports = {
                         recordPartForAssertion(lastPartOrError);
                     }
 
-                    expect(httpConversation, 'to satisfy', httpConversationSatisfySpec);
+                    expect.errorMode = 'default';
+                    return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec);
                 }).finally(function () {
                     seenAgents.forEach(function (agent) {
                         if (agent.freeSockets) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -967,7 +967,7 @@ module.exports = {
 
                             if (!hasRequestDescription) {
                                 // there was no mock so arrange "<no response>"
-                                var part = assertMockResponse(null);
+                                assertMockResponse(null);
 
                                 /*
                                  * We wish to cause the generation of a diff
@@ -985,8 +985,6 @@ module.exports = {
                                  * our output.
                                  */
 
-                                // record this portion of the exchange
-                                exchangeParts.push(part);
                                 // cancel the delegated assertion
                                 throw new SawUnexpectedRequestsError('unexpected-mitm: Saw unexpected requests.');
                             }
@@ -1037,8 +1035,7 @@ module.exports = {
                                 // continue thus respond
                                 deliverMockResponse(mockResponse, mockResponseError);
                             }).catch(function (e) {
-                                var part = assertMockResponse(mockResponse, mockResponseError);
-                                exchangeParts.push(part);
+                                assertMockResponse(mockResponse, mockResponseError);
                                 throw new EarlyExitError('Seen request did not match the expected request.');
                             });
                         }).caught(function (e) {
@@ -1095,7 +1092,7 @@ module.exports = {
                              * to the delegated assertion execution below.
                              */
 
-                            return httpPart;
+                            exchangeParts.push(httpPart);
                         }
 
                         function deliverMockResponse(mockResponse, mockResponseError) {
@@ -1134,8 +1131,7 @@ module.exports = {
                          */
                         observeResponse(res).then(function (rawBuffer) {
                             var mockResponse = createMockResponse(rawBuffer);
-                            var part = assertMockResponse(mockResponse);
-                            exchangeParts.push(part);
+                            assertMockResponse(mockResponse);
                         });
                     }));
 

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -45,6 +45,13 @@ function EarlyExitError(message) {
 };
 util.inherits(EarlyExitError, Error);
 
+function SawUnexpectedRequestsError(message) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+};
+util.inherits(SawUnexpectedRequestsError, Error);
+
 function UnexercisedMocksError() {
     Error.captureStackTrace(this, this.constructor);
     this.name = this.constructor.name;
@@ -985,7 +992,7 @@ module.exports = {
                                 // record this portion of the exchange
                                 exchangeParts.push(part);
                                 // cancel the delegated assertion
-                                throw new Error('unexpected-mitm: Saw unexpected requests.');
+                                throw new SawUnexpectedRequestsError('unexpected-mitm: Saw unexpected requests.');
                             }
 
                             if (typeof responseProperties === 'function') {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -895,7 +895,12 @@ module.exports = {
                         return expect.shift();
                     }
                 }).then(function (timeline) {
-                    var lastEventOrError = timeline[timeline.length - 1];
+                    var lastEventOrError = null;
+
+                    // pull out the last event if it exists
+                    if (timeline.length > 0) {
+                        lastEventOrError = timeline[timeline.length - 1];
+                    }
 
                     if (lastEventOrError instanceof Error) {
                         var name = lastEventOrError.name;

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -905,15 +905,11 @@ module.exports = {
                     return verifyBlock;
                 });
 
-                var __lastError;
-
                 // Keep track of the http/https agents that we have seen
                 // during the test so we can clean up afterwards:
                 var seenAgents = [];
 
                 var assertionPromise = expect.promise(function (resolve, reject) {
-                    __lastError = null;
-
                     mitm.on('request', createSerializedRequestHandler(function (req, res) {
                         if (!res.connection) {
                             // I've observed some cases where keep-alive is
@@ -1052,8 +1048,6 @@ module.exports = {
                              * do this by signalling the error on the socket.
                              */
 
-                            // record the error
-                            __lastError = e;
                             // cancel the delegated assertion
                             try {
                                 clientSocket.emit('error', e);
@@ -1149,15 +1143,6 @@ module.exports = {
                         return expect.shift();
                     }).then(function (fulfilmentValue) {
                         /*
-                         * The deletgated assertion issuing requests may have
-                         * completed successfully (i.e. silent error handling)
-                         * but a request failed our checks. Thus go to reject.
-                         */
-                        if (__lastError) {
-                            throw __lastError;
-                        }
-
-                        /*
                          * Handle the case of specified but unprocessed mocks.
                          * If there were none remaining immediately complete.
                          *
@@ -1196,12 +1181,8 @@ module.exports = {
                             resolve([fulfilmentValue]);
                         }
                     }).caught(function (e) {
-                        if (__lastError) {
-                            reject(__lastError);
-                        } else {
-                            exchangeParts.push(e);
-                            reject(e);
-                        }
+                        exchangeParts.push(e);
+                        reject(e);
                     });
                 }).spread(function (fulfilmentValue) {
                     var httpConversation = new messy.HttpConversation();

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -45,6 +45,12 @@ function EarlyExitError(message) {
 };
 util.inherits(EarlyExitError, Error);
 
+function UnexercisedMocksError() {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+};
+util.inherits(UnexercisedMocksError, Error);
+
 function checkEnvFlag(varName) {
     return process.env[varName] === 'true';
 }
@@ -885,6 +891,7 @@ module.exports = {
                 }
                 var nextRequestDescriptionIndex = 0;
 
+                var exchangeParts = [];
                 var verifyBlocks = requestDescriptions.map(function (description) {
                     var verifyBlock = description.verify || {};
                     delete description.verify;
@@ -898,9 +905,6 @@ module.exports = {
                 var seenAgents = [];
 
                 var assertionPromise = expect.promise(function (resolve, reject) {
-                    var httpConversation = new messy.HttpConversation(),
-                        httpConversationSatisfySpec = {exchanges: []};
-
                     __lastError = null;
 
                     mitm.on('request', createSerializedRequestHandler(function (req, res) {
@@ -960,7 +964,7 @@ module.exports = {
 
                             if (!hasRequestDescription) {
                                 // there was no mock so arrange "<no response>"
-                                assertMockResponse(null);
+                                var part = assertMockResponse(null);
 
                                 /*
                                  * We wish to cause the generation of a diff
@@ -978,11 +982,10 @@ module.exports = {
                                  * our output.
                                  */
 
+                                // record this portion of the exchange
+                                exchangeParts.push(part);
                                 // cancel the delegated assertion
-                                clientSocket.emit('error', new Error('unexpected-mitm: Saw unexpected requests.'));
-                                // continue with current assertion
-                                resolve([null, httpConversation, httpConversationSatisfySpec]);
-                                return [null, null];
+                                throw new Error('unexpected-mitm: Saw unexpected requests.');
                             }
 
                             if (typeof responseProperties === 'function') {
@@ -1031,7 +1034,8 @@ module.exports = {
                                 // continue thus respond
                                 deliverMockResponse(mockResponse, mockResponseError);
                             }).catch(function (e) {
-                                assertMockResponse(mockResponse, mockResponseError);
+                                var part = assertMockResponse(mockResponse, mockResponseError);
+                                exchangeParts.push(part);
                                 throw new EarlyExitError('Seen request did not match the expected request.');
                             });
                         }).caught(function (e) {
@@ -1053,26 +1057,30 @@ module.exports = {
                                  * reject the assertion. This is only safe with
                                  * Unexpected 10.15.x and above.
                                  */
-                                if (e.name === 'EarlyExitError') {
-                                    resolve([null, httpConversation, httpConversationSatisfySpec]);
-                                } else {
-                                    reject(e);
-                                }
+
+                                exchangeParts.push(e);
+                                reject(e);
                             }
                         });
 
                         function assertMockResponse(mockResponse, mockResponseError) {
                             var mockRequest = new messy.HttpRequest(requestProperties);
+                            var httpPart = {
+                                exchange: undefined,
+                                spec: undefined
+                            };
+
                             var httpExchange = new messy.HttpExchange({request: mockRequest});
                             if (mockResponse) {
                                 httpExchange.response = mockResponse;
                             } else if (mockResponseError) {
                                 httpExchange.response = mockResponseError;
                             }
-                            httpConversation.exchanges.push(httpExchange);
+                            httpPart.exchange = httpExchange;
+
                             // only attempt request validation with a mock
                             if (hasRequestDescription) {
-                                httpConversationSatisfySpec.exchanges.push({request: expectedRequestProperties});
+                                httpPart.spec = {request: expectedRequestProperties};
                             }
 
                             /*
@@ -1085,6 +1093,8 @@ module.exports = {
                              * rejection to the handler functions attached
                              * to the delegated assertion execution below.
                              */
+
+                            return httpPart;
                         }
 
                         function deliverMockResponse(mockResponse, mockResponseError) {
@@ -1123,7 +1133,8 @@ module.exports = {
                          */
                         observeResponse(res).then(function (rawBuffer) {
                             var mockResponse = createMockResponse(rawBuffer);
-                            assertMockResponse(mockResponse);
+                            var part = assertMockResponse(mockResponse);
+                            exchangeParts.push(part);
                         });
                     }));
 
@@ -1161,19 +1172,21 @@ module.exports = {
                                     }).then(function () {
                                         return getMockResponse(remainingDescription.response);
                                     }).spread(function (mockResponse, mockResponseError) {
-                                        httpConversationSatisfySpec.exchanges.push({
+                                        var spec = {
                                             request: expectedRequestProperties,
                                             response: mockResponseError || trimMockResponse(mockResponse)
-                                        });
+                                        };
+
+                                        exchangeParts.push({ spec: spec });
 
                                         return nextItem();
                                     }).caught(reject);
                                 } else {
-                                    resolve([fulfilmentValue, httpConversation, httpConversationSatisfySpec]);
+                                    throw new UnexercisedMocksError();
                                 }
                             })();
                         } else {
-                            resolve([fulfilmentValue, httpConversation, httpConversationSatisfySpec]);
+                            resolve([fulfilmentValue]);
                         }
                     }).caught(function (e) {
                         if (__lastError) {
@@ -1191,6 +1204,35 @@ module.exports = {
                             return fulfilmentValue;
                         }
                     });
+                }).catch(function (e) {
+                    var httpConversation = new messy.HttpConversation();
+                    var httpConversationSatisfySpec = { exchanges: [] };
+
+                    function recordPartForAssertion(part) {
+                        if (part.exchange) {
+                            httpConversation.exchanges.push(part.exchange);
+                        }
+                        if (part.spec) {
+                            httpConversationSatisfySpec.exchanges.push(part.spec);
+                        }
+                    }
+
+                    var lastPartOrError = exchangeParts.pop();
+
+                    exchangeParts.forEach(recordPartForAssertion);
+
+                    if (lastPartOrError instanceof Error) {
+                        var name = lastPartOrError.name;
+                        if (name === 'EarlyExitError' || name === 'UnexercisedMocksError') {
+                            // will be caught by the assertion
+                        } else {
+                            throw lastPartOrError;
+                        }
+                    } else if (lastPartOrError) {
+                        recordPartForAssertion(lastPartOrError);
+                    }
+
+                    expect(httpConversation, 'to satisfy', httpConversationSatisfySpec);
                 }).finally(function () {
                     seenAgents.forEach(function (agent) {
                         if (agent.freeSockets) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -9,7 +9,6 @@ var messy = require('messy'),
     formatHeaderObj = require('./formatHeaderObj'),
     fs = require('fs'),
     path = require('path'),
-    trimHeadersLower = require('./trimHeadersLower'),
     memoizeSync = require('memoizesync'),
     callsite = require('callsite'),
     detectIndent = require('detect-indent'),
@@ -198,7 +197,8 @@ module.exports = {
         var expectForRendering = expect.child();
 
         expect = expect.child()
-            .use(require('unexpected-messy'));
+            .use(require('unexpected-messy'))
+            .use(require('./mockerAssertions'));
 
         expectForRendering.addType({
             name: 'infiniteBuffer',
@@ -631,80 +631,7 @@ module.exports = {
                 }
 
                 return assertionPromise;
-            })
-            .exportType({
-                name: 'UnexpectedMitmMocker',
-                base: 'object',
-                identify: function (obj) {
-                    return obj instanceof UnexpectedMitmMocker;
-                }
-            })
-            .exportAssertion('<UnexpectedMitmMocker> to be complete [with extra info]', function (expect, subject) {
-                var shouldReturnExtraInfo = expect.flags['with extra info'];
-
-                return expect.promise(function () {
-                    return subject;
-                }).then(function (result) {
-                    return [result.timeline, result.fulfilmentValue];
-                }).spread(function (timeline, fulfilmentValue) {
-                    var lastEventOrError = null;
-
-                    // pull out the last event if it exists
-                    if (timeline.length > 0) {
-                        lastEventOrError = timeline[timeline.length - 1];
-                    }
-
-                    if (lastEventOrError instanceof Error) {
-                        var name = lastEventOrError.name;
-                        if (name === 'Error' || name === 'UnexpectedError') {
-                            throw lastEventOrError;
-                        } else if (name === 'EarlyExitError') {
-                            // in the case of an early exirt error we need
-                            // to generate a diff from the last recorded
-                            // event & spec
-                            var failedEvent = timeline[timeline.length - 2];
-                            var failedExchange = failedEvent.exchange;
-                            trimHeadersLower(failedExchange.request);
-
-                            expect.errorMode = 'default';
-                            return expect(failedExchange, 'to satisfy', failedEvent.spec);
-                        } else {
-                            // ignore to cause generation of a diff
-                        }
-                    } else if (lastEventOrError === null && fulfilmentValue) {
-                        return [null, fulfilmentValue];
-                    }
-
-                    return [timeline, fulfilmentValue];
-                }).spread(function (timeline, fulfilmentValue) {
-                    // in the absence of a timeline immedistely resolve with fulfilmentValue
-                    if (timeline === null) {
-                        return fulfilmentValue;
-                    }
-
-                    var httpConversation = new messy.HttpConversation();
-                    var httpConversationSatisfySpec = { exchanges: [] };
-
-                    function recordEventForAssertion(event) {
-                        if (event.exchange) {
-                            httpConversation.exchanges.push(event.exchange);
-                        }
-                        if (event.spec) {
-                            httpConversationSatisfySpec.exchanges.push(event.spec);
-                        }
-                    }
-
-                    timeline.forEach(recordEventForAssertion);
-
-                    expect.errorMode = 'default';
-                    return expect(httpConversation, 'to satisfy', httpConversationSatisfySpec).then(function () {
-                        if (shouldReturnExtraInfo) {
-                            return [fulfilmentValue, httpConversation, httpConversationSatisfySpec];
-                        } else {
-                            return fulfilmentValue;
-                        }
-                    });
-                });
             });
+
     }
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1,5 +1,6 @@
 /* global setImmediate, process, after, console */
 var messy = require('messy'),
+    createError = require('createerror'),
     createMitm = require('mitm-papandreou'),
     _ = require('underscore'),
     http = require('http'),
@@ -8,7 +9,6 @@ var messy = require('messy'),
     path = require('path'),
     stream = require('stream'),
     urlModule = require('url'),
-    util = require('util'),
     memoizeSync = require('memoizesync'),
     callsite = require('callsite'),
     detectIndent = require('detect-indent'),
@@ -38,25 +38,12 @@ var pathIsAbsolute = path.isAbsolute || function (path) {
     return false;
 };
 
-function EarlyExitError(message) {
-    Error.captureStackTrace(this, this.constructor);
-    this.name = this.constructor.name;
-    this.message = message;
-};
-util.inherits(EarlyExitError, Error);
-
-function SawUnexpectedRequestsError(message) {
-    Error.captureStackTrace(this, this.constructor);
-    this.name = this.constructor.name;
-    this.message = message;
-};
-util.inherits(SawUnexpectedRequestsError, Error);
-
-function UnexercisedMocksError() {
-    Error.captureStackTrace(this, this.constructor);
-    this.name = this.constructor.name;
-};
-util.inherits(UnexercisedMocksError, Error);
+// base error
+var UnexpectedMitmError = createError({ name: 'UnexpectedMitmError' });
+// marker errors
+var EarlyExitError = createError({ name: 'EarlyExitError' }, UnexpectedMitmError);
+var SawUnexpectedRequestsError = createError({ name: 'SawUnexpectedRequestsError' }, UnexpectedMitmError);
+var UnexercisedMocksError = createError({ name: 'UnexercisedMocksError' }, UnexpectedMitmError);
 
 function checkEnvFlag(varName) {
     return process.env[varName] === 'true';

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "callsite": "1.0.0",
+    "createerror": "1.3.0",
     "detect-indent": "3.0.0",
     "memoizesync": "0.5.0",
     "messy": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "callsite": "1.0.0",
-    "createerror": "1.3.0",
+    "createerror": "1.1.0",
     "detect-indent": "3.0.0",
     "memoizesync": "0.5.0",
     "messy": "^6.16.0",

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -368,6 +368,7 @@ describe('unexpectedMitm', function () {
                         "POST / HTTP/1.1\n" +
                         "Host: www.google.com\n" +
                         "Content-Type: application/json\n" +
+                        "Content-Length: 11\n" +
                         "\n" +
                         "expected { foo: 123 } when delayed a little bit to equal { foo: 456 }\n" +
                         "\n" +
@@ -762,6 +763,7 @@ describe('unexpectedMitm', function () {
                         'POST / HTTP/1.1\n' +
                         'Host: www.google.com\n' +
                         'Content-Type: application/json\n' +
+                        'Content-Length: 11\n' +
                         '\n' +
                         '{\n' +
                         '  foo: 123 // should equal 456\n' +

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -388,9 +388,11 @@ describe('unexpectedMitm', function () {
     });
 
     it('should not break when the assertion being delegated to throws synchronously', function () {
-        expect(function () {
-            expect('http://www.google.com/', 'with http mocked out', [], 'to foobarquux');
-        }, 'to throw', /^Unknown assertion 'to foobarquux'/);
+        return expect(
+            expect('http://www.google.com/', 'with http mocked out', [], 'to foobarquux'),
+            'to be rejected with',
+            /^Unknown assertion 'to foobarquux'/
+        );
     });
 
     describe('when mocking out an https request and asserting that the request is https', function () {

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -368,7 +368,6 @@ describe('unexpectedMitm', function () {
                         "POST / HTTP/1.1\n" +
                         "Host: www.google.com\n" +
                         "Content-Type: application/json\n" +
-                        "Content-Length: 11\n" +
                         "\n" +
                         "expected { foo: 123 } when delayed a little bit to equal { foo: 456 }\n" +
                         "\n" +
@@ -765,7 +764,6 @@ describe('unexpectedMitm', function () {
                         'POST / HTTP/1.1\n' +
                         'Host: www.google.com\n' +
                         'Content-Type: application/json\n' +
-                        'Content-Length: 11\n' +
                         '\n' +
                         '{\n' +
                         '  foo: 123 // should equal 456\n' +

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -1164,12 +1164,11 @@ describe('unexpectedMitm', function () {
             'to have message', function (message) {
                 expect(trimDiff(message), 'to equal',
                     "expected 'http://www.google.com/foo' with http mocked out { request: 'GET /foo', response: 200 } to yield response 412\n" +
-                    "  expected 'http://www.google.com/foo' to yield response 412\n" +
                     '\n' +
-                    '  GET /foo HTTP/1.1\n' +
-                    '  Host: www.google.com\n' +
+                    'GET /foo HTTP/1.1\n' +
+                    'Host: www.google.com\n' +
                     '\n' +
-                    '  HTTP/1.1 200 OK // should be 412 Precondition Failed\n'
+                    'HTTP/1.1 200 OK // should be 412 Precondition Failed\n'
                 );
             }
         );

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -622,6 +622,35 @@ describe('unexpectedMitm', function () {
             });
         });
 
+        it('should treat Content-Length case insentitively', function () {
+            return expect('http://www.google.com/', 'with http mocked out', {
+                request: 'GET /',
+                response: {
+                    headers: {
+                        'content-length': 5
+                    },
+                    body: new Buffer('hello')
+                }
+            }, 'to yield response', 200);
+        });
+
+        it('should treat Transfer-Encoding case insentitively', function () {
+            return expect(function () {
+                return expect.promise(function (run) {
+                    issueGetAndConsume('http://www.google.com/', run(function () {}));
+                });
+            }, 'with http mocked out', {
+                request: 'GET /',
+                response: {
+                    headers: {
+                        'transfer-encoding': 'chunked',
+                        'content-length': 1
+                    },
+                    body: fs.createReadStream(pathModule.resolve(__dirname, '..', 'testdata', 'foo.txt'))
+                }
+            }, 'not to error');
+        });
+
         describe('that emits an error', function () {
             it('should propagate the error to the mocked-out HTTP response', function () {
                 var erroringStream = new stream.Readable();


### PR DESCRIPTION
@papandreou I managed to get a branch working that has some kind of split between the exchanges it sees and the asserting portion - it uses named errors for the various cases and asserts/throws as appropriate. It passes the entire test suite so pushing as I'm really keen to see what you think.