### PR TITLE
Separate recorder

### DIFF
--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -495,7 +495,7 @@ class UnexpectedMitmMocker {
       let consumer;
       try {
         const consumerResult = consumptionFunction();
-        // ensure consumption function result is a promises
+        // ensure consumption function result is a promise
         consumer = Promise.resolve(consumerResult);
       } catch (e) {
         timeline.push(e);

--- a/lib/UnexpectedMitmRecorder.js
+++ b/lib/UnexpectedMitmRecorder.js
@@ -251,10 +251,15 @@ class UnexpectedMitmRecorder {
       .catch(e => {
         cleanup();
 
+        timeline.push(e);
+
         this.timeline = timeline;
         this.fulfilmentValue = null;
 
-        throw e;
+        return {
+          timeline,
+          fulfilmentValue: null
+        };
       });
   }
 }

--- a/lib/UnexpectedMitmRecorder.js
+++ b/lib/UnexpectedMitmRecorder.js
@@ -98,10 +98,16 @@ function trimRecordedExchange(recordedExchange) {
 }
 
 class UnexpectedMitmRecorder {
+  constructor(options) {
+    this.timeline = null;
+    this.fulfilmentValue = null;
+  }
+
   record(consumptionFunction) {
     const mitm = createMitm();
 
-    let recordedExchanges = [];
+    // accumulator for events
+    const timeline = [];
 
     function cleanup() {
       mitm.disable();
@@ -141,7 +147,10 @@ class UnexpectedMitmRecorder {
               ),
               response: {}
             };
-            recordedExchanges.push(recordedExchange);
+
+            // capture the exchange early so we record at least headers
+            timeline.push(recordedExchange);
+
             consumeReadableStream(req)
               .catch(reject)
               .then(result => {
@@ -156,9 +165,7 @@ class UnexpectedMitmRecorder {
                   req.headers.host.match(/^([^:]*)(?::(\d+))?/);
 
                 let host;
-
                 let port;
-
                 // https://github.com/moll/node-mitm/issues/14
                 if (matchHostHeader) {
                   if (matchHostHeader[1]) {
@@ -228,22 +235,30 @@ class UnexpectedMitmRecorder {
         return reject(e);
       }
 
-      consumer.catch(reject).then(fulfilmentValue => {
-        recordedExchanges = recordedExchanges.map(trimRecordedExchange);
-        if (recordedExchanges.length === 1) {
-          recordedExchanges = recordedExchanges[0];
-        }
-
-        resolve([fulfilmentValue, recordedExchanges]);
-      });
+      consumer.then(resolve).catch(reject);
     })
-      .then(result => {
+      .then(fulfilmentValue => {
         cleanup();
 
-        return result;
+        let trimmedTimeline = timeline.map(trimRecordedExchange);
+        if (trimmedTimeline.length === 1) {
+          // serialize a single exchange as an object
+          trimmedTimeline = trimmedTimeline[0];
+        }
+
+        this.fulfilmentValue = fulfilmentValue;
+        this.timeline = trimmedTimeline;
+
+        return {
+          timeline: this.timeline,
+          fulfilmentValue
+        };
       })
       .catch(e => {
         cleanup();
+
+        this.timeline = timeline;
+        this.fulfilmentValue = null;
 
         throw e;
       });

--- a/lib/UnexpectedMitmRecorder.js
+++ b/lib/UnexpectedMitmRecorder.js
@@ -1,4 +1,4 @@
-const _ = require('lodash');
+const _ = require('underscore');
 const messy = require('messy');
 const createMitm = require('mitm-papandreou');
 

--- a/lib/UnexpectedMitmRecorder.js
+++ b/lib/UnexpectedMitmRecorder.js
@@ -240,14 +240,8 @@ class UnexpectedMitmRecorder {
       .then(fulfilmentValue => {
         cleanup();
 
-        let trimmedTimeline = timeline.map(trimRecordedExchange);
-        if (trimmedTimeline.length === 1) {
-          // serialize a single exchange as an object
-          trimmedTimeline = trimmedTimeline[0];
-        }
-
         this.fulfilmentValue = fulfilmentValue;
-        this.timeline = trimmedTimeline;
+        this.timeline = timeline.map(trimRecordedExchange);
 
         return {
           timeline: this.timeline,

--- a/lib/UnexpectedMitmRecorder.js
+++ b/lib/UnexpectedMitmRecorder.js
@@ -1,0 +1,253 @@
+const _ = require('lodash');
+const messy = require('messy');
+const createMitm = require('mitm-papandreou');
+
+const consumeReadableStream = require('./consumeReadableStream');
+const createSerializedRequestHandler = require('./createSerializedRequestHandler');
+const formatHeaderObj = require('./formatHeaderObj');
+const performRequest = require('./performRequest');
+const trimHeaders = require('./trimHeaders');
+
+const metadataPropertyNames = messy.HttpRequest.metadataPropertyNames.concat(
+  'rejectUnauthorized'
+);
+
+function bufferCanBeInterpretedAsUtf8(buffer) {
+  // Hack: Since Buffer.prototype.toString('utf-8') is very forgiving, convert the buffer to a string
+  // with percent-encoded octets, then see if decodeURIComponent accepts it.
+  try {
+    decodeURIComponent(
+      Array.prototype.map
+        .call(buffer, octet => `%${octet < 16 ? '0' : ''}${octet.toString(16)}`)
+        .join('')
+    );
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
+function isTextualBody(message, content) {
+  return message.hasTextualContentType && bufferCanBeInterpretedAsUtf8(content);
+}
+
+function trimMessage(message) {
+  if (typeof message.body !== 'undefined') {
+    if (message.body.length === 0) {
+      delete message.body;
+    } else if (
+      isTextualBody(
+        new messy.Message({
+          headers: { 'Content-Type': message.headers['Content-Type'] }
+        }),
+        message.body
+      )
+    ) {
+      message.body = message.body.toString('utf-8');
+    }
+    if (
+      /^application\/json(?:;|$)|\+json\b/.test(
+        message.headers['Content-Type']
+      ) &&
+      /^\s*[[{]/.test(message.body)
+    ) {
+      try {
+        message.body = JSON.parse(message.body);
+        if (message.headers['Content-Type'] === 'application/json') {
+          delete message.headers['Content-Type'];
+        }
+      } catch (e) {}
+    }
+  }
+  if (message.statusCode === 200) {
+    delete message.statusCode;
+  }
+  if (message.headers) {
+    trimHeaders(message);
+    if (Object.keys(message.headers).length === 0) {
+      delete message.headers;
+    }
+  }
+  if (message.url && message.method) {
+    message.url = `${message.method} ${message.url}`;
+    delete message.method;
+  }
+  // Remove properties with an undefined value. Prevents things
+  // like rejectUnauthorized:true from showing up in recordings:
+  Object.keys(message).forEach(key => {
+    if (typeof message[key] === 'undefined') {
+      delete message[key];
+    }
+  });
+  if (Object.keys(message).length === 1) {
+    if (typeof message.url === 'string') {
+      return message.url;
+    }
+    if (typeof message.statusCode === 'number') {
+      return message.statusCode;
+    }
+  }
+  return message;
+}
+
+function trimRecordedExchange(recordedExchange) {
+  return {
+    request: trimMessage(recordedExchange.request),
+    response: trimMessage(recordedExchange.response)
+  };
+}
+
+class UnexpectedMitmRecorder {
+  record(consumptionFunction) {
+    const mitm = createMitm();
+
+    let recordedExchanges = [];
+
+    function cleanup() {
+      mitm.disable();
+    }
+
+    return new Promise((resolve, reject) => {
+      let bypassNextConnect = false;
+
+      mitm
+        .on('connect', (socket, opts) => {
+          if (bypassNextConnect) {
+            socket.bypass();
+            bypassNextConnect = false;
+          }
+        })
+        .on(
+          'request',
+          createSerializedRequestHandler((req, res) => {
+            const clientSocket = req.connection._mitm.client;
+            const clientSocketOptions = req.connection._mitm.opts;
+            const metadata = Object.assign(
+              {},
+              _.pick(
+                clientSocketOptions.agent && clientSocketOptions.agent.options,
+                metadataPropertyNames
+              ),
+              _.pick(clientSocketOptions, metadataPropertyNames)
+            );
+
+            const recordedExchange = {
+              request: Object.assign(
+                {
+                  url: `${req.method} ${req.url}`,
+                  headers: formatHeaderObj(req.headers)
+                },
+                metadata
+              ),
+              response: {}
+            };
+            recordedExchanges.push(recordedExchange);
+            consumeReadableStream(req)
+              .catch(reject)
+              .then(result => {
+                if (result.error) {
+                  // TODO: Consider adding support for recording this (the request erroring out while we're recording it)
+                  return reject(result.error);
+                }
+                recordedExchange.request.body = result.body;
+                bypassNextConnect = true;
+                const matchHostHeader =
+                  req.headers.host &&
+                  req.headers.host.match(/^([^:]*)(?::(\d+))?/);
+
+                let host;
+
+                let port;
+
+                // https://github.com/moll/node-mitm/issues/14
+                if (matchHostHeader) {
+                  if (matchHostHeader[1]) {
+                    host = matchHostHeader[1];
+                  }
+                  if (matchHostHeader[2]) {
+                    port = parseInt(matchHostHeader[2], 10);
+                  }
+                }
+                if (!host) {
+                  return reject(
+                    new Error(
+                      `unexpected-mitm recording mode: Could not determine the host name from Host header: ${
+                        req.headers.host
+                      }`
+                    )
+                  );
+                }
+
+                performRequest({
+                  encrypted: req.socket.encrypted,
+                  headers: req.headers,
+                  method: req.method,
+                  host,
+                  // default the port to HTTP values if not set
+                  port: port || (req.socket.encrypted ? 443 : 80),
+                  path: req.url,
+                  body: result.body,
+                  metadata
+                })
+                  .then(responseResult => {
+                    recordedExchange.response.statusCode =
+                      responseResult.statusCode;
+                    recordedExchange.response.headers = formatHeaderObj(
+                      responseResult.headers
+                    );
+                    recordedExchange.response.body = responseResult.body;
+
+                    setImmediate(() => {
+                      res.statusCode = responseResult.statusCode;
+                      Object.keys(responseResult.headers).forEach(
+                        headerName => {
+                          res.setHeader(
+                            headerName,
+                            responseResult.headers[headerName]
+                          );
+                        }
+                      );
+                      res.end(recordedExchange.response.body);
+                    });
+                  })
+                  .catch(err => {
+                    recordedExchange.response = err;
+                    clientSocket.emit('error', err);
+                  });
+              });
+          })
+        );
+
+      // handle synchronous throws
+      let consumer;
+      try {
+        const consumerResult = consumptionFunction();
+        // ensure consumption function result is a promises
+        consumer = Promise.resolve(consumerResult);
+      } catch (e) {
+        return reject(e);
+      }
+
+      consumer.catch(reject).then(fulfilmentValue => {
+        recordedExchanges = recordedExchanges.map(trimRecordedExchange);
+        if (recordedExchanges.length === 1) {
+          recordedExchanges = recordedExchanges[0];
+        }
+
+        resolve([fulfilmentValue, recordedExchanges]);
+      });
+    })
+      .then(result => {
+        cleanup();
+
+        return result;
+      })
+      .catch(e => {
+        cleanup();
+
+        throw e;
+      });
+  }
+}
+
+module.exports = UnexpectedMitmRecorder;

--- a/lib/UnexpectedMitmRecorder.js
+++ b/lib/UnexpectedMitmRecorder.js
@@ -229,7 +229,7 @@ class UnexpectedMitmRecorder {
       let consumer;
       try {
         const consumerResult = consumptionFunction();
-        // ensure consumption function result is a promises
+        // ensure consumption function result is a promise
         consumer = Promise.resolve(consumerResult);
       } catch (e) {
         return reject(e);

--- a/lib/mockerAssertions.js
+++ b/lib/mockerAssertions.js
@@ -1,6 +1,8 @@
 const messy = require('messy');
+
 const trimHeadersLower = require('./trimHeadersLower');
 const UnexpectedMitmMocker = require('./UnexpectedMitmMocker');
+const UnexpectedMitmRecorder = require('./UnexpectedMitmRecorder');
 
 module.exports = {
   name: 'unexpected-mitm-mocker',
@@ -16,11 +18,16 @@ module.exports = {
           return obj instanceof UnexpectedMitmMocker;
         }
       })
+      .exportType({
+        name: 'UnexpectedMitmRecorder',
+        base: 'object',
+        identify(obj) {
+          return obj instanceof UnexpectedMitmRecorder;
+        }
+      })
       .exportAssertion(
-        '<UnexpectedMitmMocker> to be complete [with extra info]',
+        '<UnexpectedMitmMocker|UnexpectedMitmRecorder> to contain no errors',
         (expect, subject) => {
-          const shouldReturnExtraInfo = expect.flags['with extra info'];
-
           return expect
             .promise(() => subject)
             .then(result => [result.timeline, result.fulfilmentValue])
@@ -54,8 +61,16 @@ module.exports = {
               }
 
               return [timeline, fulfilmentValue];
-            })
-            .then(([timeline, fulfilmentValue]) => {
+            });
+        }
+      )
+      .exportAssertion(
+        '<UnexpectedMitmMocker> to be complete [with extra info]',
+        (expect, subject) => {
+          const shouldReturnExtraInfo = expect.flags['with extra info'];
+
+          return expect(subject, 'to contain no errors').then(
+            ([timeline, fulfilmentValue]) => {
               // in the absence of a timeline immedistely resolve with fulfilmentValue
               if (timeline === null) {
                 return fulfilmentValue;
@@ -91,7 +106,8 @@ module.exports = {
                   return fulfilmentValue;
                 }
               });
-            });
+            }
+          );
         }
       );
   }

--- a/lib/mockerAssertions.js
+++ b/lib/mockerAssertions.js
@@ -71,7 +71,7 @@ module.exports = {
 
           return expect(subject, 'to contain no errors').then(
             ([timeline, fulfilmentValue]) => {
-              // in the absence of a timeline immedistely resolve with fulfilmentValue
+              // in the absence of a timeline immediately resolve with fulfilmentValue
               if (timeline === null) {
                 return fulfilmentValue;
               }

--- a/lib/performRequest.js
+++ b/lib/performRequest.js
@@ -1,0 +1,40 @@
+const http = require('http');
+const https = require('https');
+
+const consumeReadableStream = require('./consumeReadableStream');
+
+module.exports = function performRequest(requestResult) {
+  return new Promise((resolve, reject) => {
+    (requestResult.encrypted ? https : http)
+      .request(
+        Object.assign(
+          {
+            headers: requestResult.headers,
+            method: requestResult.method,
+            host: requestResult.host,
+            port: requestResult.port,
+            path: requestResult.path
+          },
+          requestResult.metadata
+        )
+      )
+      .on('response', response => {
+        consumeReadableStream(response)
+          .catch(reject)
+          .then(result => {
+            if (result.error) {
+              // TODO: Consider adding support for recording this (the upstream response erroring out while we're recording it)
+              return reject(result.error);
+            }
+
+            resolve({
+              statusCode: response.statusCode,
+              headers: response.headers,
+              body: result.body
+            });
+          });
+      })
+      .on('error', reject)
+      .end(requestResult.body);
+  });
+};

--- a/lib/trimHeaders.js
+++ b/lib/trimHeaders.js
@@ -1,0 +1,6 @@
+module.exports = function trimHeaders(message) {
+  delete message.headers['Content-Length'];
+  delete message.headers['Transfer-Encoding'];
+  delete message.headers.Connection;
+  delete message.headers.Date;
+};

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -334,7 +334,7 @@ module.exports = {
       .exportAssertion(
         '<any> with http recorded [and injected] [with extra info] <assertion>',
         function(expect, subject) {
-          expect.errorMode = 'nested';
+          expect.errorMode = 'default';
           const stack = callsite();
           const injectIntoTest = this.flags['and injected'];
 
@@ -346,7 +346,12 @@ module.exports = {
           const recorder = new UnexpectedMitmRecorder();
 
           return expect
-            .promise(() => recorder.record(() => expect.shift()))
+            .promise(() =>
+              recorder.record(() => {
+                expect.errorMode = 'nested';
+                return expect.shift();
+              })
+            )
             .then(result => [result.fulfilmentValue, result.timeline])
             .then(([fulfilmentValue, recordedExchanges]) => {
               if (injectIntoTest) {

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -347,6 +347,7 @@ module.exports = {
 
           return expect
             .promise(() => recorder.record(() => expect.shift()))
+            .then(result => [result.fulfilmentValue, result.timeline])
             .then(([fulfilmentValue, recordedExchanges]) => {
               if (injectIntoTest) {
                 const injectionCallsite = determineCallsite(stack);
@@ -381,6 +382,7 @@ module.exports = {
 
             return expect
               .promise(() => recorder.record(() => expect.shift()))
+              .then(result => [result.fulfilmentValue, result.timeline])
               .then(([fulfilmentValue, recordedExchanges]) => {
                 const output = `module.exports = ${stringify(
                   recordedExchanges,

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -352,8 +352,11 @@ module.exports = {
                 return expect.shift();
               })
             )
-            .then(result => [result.fulfilmentValue, result.timeline])
-            .then(([fulfilmentValue, recordedExchanges]) => {
+            .then(() => {
+              expect.errorMode = 'bubble';
+              return expect(recorder, 'to contain no errors');
+            })
+            .then(([recordedExchanges, fulfilmentValue]) => {
               // serialize a single exchange as an object
               if (
                 Array.isArray(recordedExchanges) &&
@@ -394,8 +397,8 @@ module.exports = {
 
             return expect
               .promise(() => recorder.record(() => expect.shift()))
-              .then(result => [result.fulfilmentValue, result.timeline])
-              .then(([fulfilmentValue, recordedExchanges]) => {
+              .then(() => expect(recorder, 'to contain no errors'))
+              .then(([recordedExchanges]) => {
                 // serialize a single exchange as an object
                 if (
                   Array.isArray(recordedExchanges) &&

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1,12 +1,12 @@
 /* global setImmediate, process, after, console */
 const messy = require('messy');
-const formatHeaderObj = require('./formatHeaderObj');
 const fs = require('fs');
 const path = require('path');
 const memoizeSync = require('memoizesync');
 const callsite = require('callsite');
 const detectIndent = require('detect-indent');
 
+const formatHeaderObj = require('./formatHeaderObj');
 const performRequest = require('./performRequest');
 const trimHeaders = require('./trimHeaders');
 const UnexpectedMitmMocker = require('./UnexpectedMitmMocker');

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -396,8 +396,16 @@ module.exports = {
             const recorder = new UnexpectedMitmRecorder();
 
             return expect
-              .promise(() => recorder.record(() => expect.shift()))
-              .then(() => expect(recorder, 'to contain no errors'))
+              .promise(() =>
+                recorder.record(() => {
+                  expect.errorMode = 'nested';
+                  return expect.shift();
+                })
+              )
+              .then(() => {
+                expect.errorMode = 'bubble';
+                return expect(recorder, 'to contain no errors');
+              })
               .then(([recordedExchanges]) => {
                 // serialize a single exchange as an object
                 if (

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -354,6 +354,13 @@ module.exports = {
             )
             .then(result => [result.fulfilmentValue, result.timeline])
             .then(([fulfilmentValue, recordedExchanges]) => {
+              // serialize a single exchange as an object
+              if (
+                Array.isArray(recordedExchanges) &&
+                recordedExchanges.length === 1
+              ) {
+                recordedExchanges = recordedExchanges[0];
+              }
               if (injectIntoTest) {
                 const injectionCallsite = determineCallsite(stack);
                 if (injectionCallsite) {
@@ -389,6 +396,13 @@ module.exports = {
               .promise(() => recorder.record(() => expect.shift()))
               .then(result => [result.fulfilmentValue, result.timeline])
               .then(([fulfilmentValue, recordedExchanges]) => {
+                // serialize a single exchange as an object
+                if (
+                  Array.isArray(recordedExchanges) &&
+                  recordedExchanges.length === 1
+                ) {
+                  recordedExchanges = recordedExchanges[0];
+                }
                 const output = `module.exports = ${stringify(
                   recordedExchanges,
                   4

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -1,44 +1,19 @@
 /* global setImmediate, process, after, console */
 const messy = require('messy');
-const consumeReadableStream = require('./consumeReadableStream');
-const createMitm = require('mitm-papandreou');
-const createSerializedRequestHandler = require('./createSerializedRequestHandler');
-const _ = require('underscore');
-const http = require('http');
-const https = require('https');
 const formatHeaderObj = require('./formatHeaderObj');
 const fs = require('fs');
 const path = require('path');
 const memoizeSync = require('memoizesync');
 const callsite = require('callsite');
 const detectIndent = require('detect-indent');
-const metadataPropertyNames = messy.HttpRequest.metadataPropertyNames.concat(
-  'rejectUnauthorized'
-);
 
+const performRequest = require('./performRequest');
+const trimHeaders = require('./trimHeaders');
 const UnexpectedMitmMocker = require('./UnexpectedMitmMocker');
+const UnexpectedMitmRecorder = require('./UnexpectedMitmRecorder');
 
 function checkEnvFlag(varName) {
   return process.env[varName] === 'true';
-}
-
-function isTextualBody(message, content) {
-  return message.hasTextualContentType && bufferCanBeInterpretedAsUtf8(content);
-}
-
-function bufferCanBeInterpretedAsUtf8(buffer) {
-  // Hack: Since Buffer.prototype.toString('utf-8') is very forgiving, convert the buffer to a string
-  // with percent-encoded octets, then see if decodeURIComponent accepts it.
-  try {
-    decodeURIComponent(
-      Array.prototype.map
-        .call(buffer, octet => `%${octet < 16 ? '0' : ''}${octet.toString(16)}`)
-        .join('')
-    );
-  } catch (e) {
-    return false;
-  }
-  return true;
 }
 
 function lineNumberToIndex(string, lineNumber) {
@@ -53,79 +28,6 @@ function lineNumberToIndex(string, lineNumber) {
   }
 
   return startOfLineIndex;
-}
-
-function trimHeaders(message) {
-  delete message.headers['Content-Length'];
-  delete message.headers['Transfer-Encoding'];
-  delete message.headers.Connection;
-  delete message.headers.Date;
-}
-
-function trimMessage(message) {
-  if (typeof message.body !== 'undefined') {
-    if (message.body.length === 0) {
-      delete message.body;
-    } else if (
-      isTextualBody(
-        new messy.Message({
-          headers: { 'Content-Type': message.headers['Content-Type'] }
-        }),
-        message.body
-      )
-    ) {
-      message.body = message.body.toString('utf-8');
-    }
-    if (
-      /^application\/json(?:;|$)|\+json\b/.test(
-        message.headers['Content-Type']
-      ) &&
-      /^\s*[[{]/.test(message.body)
-    ) {
-      try {
-        message.body = JSON.parse(message.body);
-        if (message.headers['Content-Type'] === 'application/json') {
-          delete message.headers['Content-Type'];
-        }
-      } catch (e) {}
-    }
-  }
-  if (message.statusCode === 200) {
-    delete message.statusCode;
-  }
-  if (message.headers) {
-    trimHeaders(message);
-    if (Object.keys(message.headers).length === 0) {
-      delete message.headers;
-    }
-  }
-  if (message.url && message.method) {
-    message.url = `${message.method} ${message.url}`;
-    delete message.method;
-  }
-  // Remove properties with an undefined value. Prevents things
-  // like rejectUnauthorized:true from showing up in recordings:
-  Object.keys(message).forEach(key => {
-    if (typeof message[key] === 'undefined') {
-      delete message[key];
-    }
-  });
-  if (Object.keys(message).length === 1) {
-    if (typeof message.url === 'string') {
-      return message.url;
-    }
-    if (typeof message.statusCode === 'number') {
-      return message.statusCode;
-    }
-  }
-  return message;
-}
-
-function trimRecordedExchange(recordedExchange) {
-  return {
-    request: trimMessage(recordedExchange.request),
-    response: trimMessage(recordedExchange.response)
-  };
 }
 
 function determineCallsite(stack) {
@@ -337,42 +239,6 @@ module.exports = {
       }
     }
 
-    function performRequest(requestResult) {
-      return expect.promise((resolve, reject) => {
-        (requestResult.encrypted ? https : http)
-          .request(
-            Object.assign(
-              {
-                headers: requestResult.headers,
-                method: requestResult.method,
-                host: requestResult.host,
-                port: requestResult.port,
-                path: requestResult.path
-              },
-              requestResult.metadata
-            )
-          )
-          .on('response', response => {
-            consumeReadableStream(response)
-              .catch(reject)
-              .then(result => {
-                if (result.error) {
-                  // TODO: Consider adding support for recording this (the upstream response erroring out while we're recording it)
-                  return reject(result.error);
-                }
-
-                resolve({
-                  statusCode: response.statusCode,
-                  headers: response.headers,
-                  body: result.body
-                });
-              });
-          })
-          .on('error', reject)
-          .end(requestResult.body);
-      });
-    }
-
     function applyInjections() {
       Object.keys(injectionsBySourceFileName).forEach(sourceFileName => {
         const injections = injectionsBySourceFileName[sourceFileName];
@@ -462,141 +328,6 @@ module.exports = {
       };
     }
 
-    function executeMitm(expect, subject) {
-      const mitm = createMitm();
-
-      let recordedExchanges = [];
-
-      return expect
-        .promise((resolve, reject) => {
-          let bypassNextConnect = false;
-
-          mitm
-            .on('connect', (socket, opts) => {
-              if (bypassNextConnect) {
-                socket.bypass();
-                bypassNextConnect = false;
-              }
-            })
-            .on(
-              'request',
-              createSerializedRequestHandler((req, res) => {
-                const clientSocket = req.connection._mitm.client;
-                const clientSocketOptions = req.connection._mitm.opts;
-                const metadata = Object.assign(
-                  {},
-                  _.pick(
-                    clientSocketOptions.agent &&
-                      clientSocketOptions.agent.options,
-                    metadataPropertyNames
-                  ),
-                  _.pick(clientSocketOptions, metadataPropertyNames)
-                );
-
-                const recordedExchange = {
-                  request: Object.assign(
-                    {
-                      url: `${req.method} ${req.url}`,
-                      headers: formatHeaderObj(req.headers)
-                    },
-                    metadata
-                  ),
-                  response: {}
-                };
-                recordedExchanges.push(recordedExchange);
-                consumeReadableStream(req)
-                  .catch(reject)
-                  .then(result => {
-                    if (result.error) {
-                      // TODO: Consider adding support for recording this (the request erroring out while we're recording it)
-                      return reject(result.error);
-                    }
-                    recordedExchange.request.body = result.body;
-                    bypassNextConnect = true;
-                    const matchHostHeader =
-                      req.headers.host &&
-                      req.headers.host.match(/^([^:]*)(?::(\d+))?/);
-
-                    let host;
-
-                    let port;
-
-                    // https://github.com/moll/node-mitm/issues/14
-                    if (matchHostHeader) {
-                      if (matchHostHeader[1]) {
-                        host = matchHostHeader[1];
-                      }
-                      if (matchHostHeader[2]) {
-                        port = parseInt(matchHostHeader[2], 10);
-                      }
-                    }
-                    if (!host) {
-                      return reject(
-                        new Error(
-                          `unexpected-mitm recording mode: Could not determine the host name from Host header: ${
-                            req.headers.host
-                          }`
-                        )
-                      );
-                    }
-
-                    performRequest({
-                      encrypted: req.socket.encrypted,
-                      headers: req.headers,
-                      method: req.method,
-                      host,
-                      // default the port to HTTP values if not set
-                      port: port || (req.socket.encrypted ? 443 : 80),
-                      path: req.url,
-                      body: result.body,
-                      metadata
-                    })
-                      .then(responseResult => {
-                        recordedExchange.response.statusCode =
-                          responseResult.statusCode;
-                        recordedExchange.response.headers = formatHeaderObj(
-                          responseResult.headers
-                        );
-                        recordedExchange.response.body = responseResult.body;
-
-                        setImmediate(() => {
-                          res.statusCode = responseResult.statusCode;
-                          Object.keys(responseResult.headers).forEach(
-                            headerName => {
-                              res.setHeader(
-                                headerName,
-                                responseResult.headers[headerName]
-                              );
-                            }
-                          );
-                          res.end(recordedExchange.response.body);
-                        });
-                      })
-                      .catch(err => {
-                        recordedExchange.response = err;
-                        clientSocket.emit('error', err);
-                      });
-                  });
-              })
-            );
-
-          expect
-            .promise(() => expect.shift())
-            .catch(reject)
-            .then(value => {
-              recordedExchanges = recordedExchanges.map(trimRecordedExchange);
-              if (recordedExchanges.length === 1) {
-                recordedExchanges = recordedExchanges[0];
-              }
-
-              resolve([value, recordedExchanges]);
-            });
-        })
-        .finally(() => {
-          mitm.disable();
-        });
-    }
-
     let afterBlockRegistered = false;
 
     expect
@@ -612,8 +343,11 @@ module.exports = {
             afterBlockRegistered = true;
           }
 
-          return executeMitm(expect, subject).then(
-            ([value, recordedExchanges]) => {
+          const recorder = new UnexpectedMitmRecorder();
+
+          return expect
+            .promise(() => recorder.record(() => expect.shift()))
+            .then(([fulfilmentValue, recordedExchanges]) => {
               if (injectIntoTest) {
                 const injectionCallsite = determineCallsite(stack);
                 if (injectionCallsite) {
@@ -621,12 +355,11 @@ module.exports = {
                 }
               }
               if (expect.flags['with extra info']) {
-                return [value, recordedExchanges];
+                return [fulfilmentValue, recordedExchanges];
               } else {
-                return value;
+                return fulfilmentValue;
               }
-            }
-          );
+            });
         }
       )
       .exportAssertion(
@@ -644,8 +377,11 @@ module.exports = {
           }
 
           if (checkEnvFlag('UNEXPECTED_MITM_WRITE')) {
-            return executeMitm(expect, subject).then(
-              ([fulfilmentValue, recordedExchanges]) => {
+            const recorder = new UnexpectedMitmRecorder();
+
+            return expect
+              .promise(() => recorder.record(() => expect.shift()))
+              .then(([fulfilmentValue, recordedExchanges]) => {
                 const output = `module.exports = ${stringify(
                   recordedExchanges,
                   4
@@ -658,8 +394,7 @@ module.exports = {
                 } else {
                   return recordedExchanges;
                 }
-              }
-            );
+              });
           }
 
           return expect

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -2393,7 +2393,7 @@ describe('unexpectedMitm', () => {
             trimDiff(message),
             'to begin with',
             "expected 'http://www.google.com/foo'\n" +
-              "with http mocked out by file '/Users/alex/Documents/projects/unexpected-mitm/replay/capture.js' to yield response 412\n" +
+              `with http mocked out by file '${outputFile}' to yield response 412\n` +
               "  expected 'http://www.google.com/foo' to yield response 412\n" +
               '\n' +
               '  GET /foo HTTP/1.1\n' +

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -2126,6 +2126,13 @@ describe('unexpectedMitm', () => {
           );
         }
       ));
+
+    it('should not break when the assertion being delegated to throws synchronously', () =>
+      expect(
+        expect('http://www.google.com/', 'with http recorded', 'to foobarquux'),
+        'to be rejected with',
+        /^Unknown assertion 'to foobarquux'/
+      ));
   });
 
   describe('in injecting mode against a local HTTP server', () => {


### PR DESCRIPTION
This PR splits our the http recorder from the unexpected-mitm assertion code and uses a similar approach to the mocker to allow a self contained `UnexpectedMitmRecorder` that is constructed and whose instances can subsequently be asserted against.

The current assertions making use of recording functionality are converted to make use of this new class. The set of internal assertions used to validate the mocker are expanded to support checking the recorder contained no errors and throwing it it did.