### PR TITLE
Change unexpected-documentation-site-generator to a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
   "peerDependencies": {
     "unexpected": "^10.27.0 || ^11.0.0-3"
   },
-  "optionalDependencies": {
-    "unexpected-documentation-site-generator": "^5.0.0"
-  },
   "devDependencies": {
     "body-parser": "^1.18.2",
     "coveralls": "^3.0.0",
@@ -42,6 +39,7 @@
     "sinon": "^7.0.0",
     "socketerrors-papandreou": "^0.2.0-patch2",
     "unexpected": "^11.0.0-3",
+    "unexpected-documentation-site-generator": "^5.0.0",
     "unexpected-express": "^11.0.0",
     "unexpected-http": "^6.0.0",
     "unexpected-markdown": "^3.0.0",


### PR DESCRIPTION
It was moved from devDeps to optionalDependencies in this commit:
https://github.com/unexpectedjs/unexpected-mitm/commit/1efd196cf5d62e5b0f384e5fc2f753a58f505b26

I tested installing the module on node 6 and did not find any errors, so
it seems safe to "revert" this change.

And optionalDependency is not a suitable replacement for a devDependency
as it will also be installed when consumers install the module. If this
change is not enough, we might need to consider installing it lazily -
as in, only install it just-in-time before invoking the build commands.

Fixes #81 