### PR TITLE
Use objects for internal request and response state within Mocker.

### DIFF
--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -233,17 +233,15 @@ class UnexpectedMitmMocker {
 
     function handleRequest(req, metadata, spec) {
       return consumeReadableStream(req, { skipConcat: true }).then(result => {
-        const properties = Object.assign(
-          {
-            method: req.method,
-            path: req.url,
-            protocolName: 'HTTP',
-            protocolVersion: req.httpVersion,
-            headers: req.headers,
-            unchunkedBody: Buffer.concat(result.body)
-          },
-          metadata
-        );
+        const properties = {
+          method: req.method,
+          path: req.url,
+          protocolName: 'HTTP',
+          protocolVersion: req.httpVersion,
+          headers: req.headers,
+          unchunkedBody: Buffer.concat(result.body),
+          ...metadata
+        };
         const request = new messy.HttpRequest(properties);
 
         return {
@@ -274,7 +272,7 @@ class UnexpectedMitmMocker {
         spec = { request: requestStruct.spec };
       }
 
-      // We explicitly do not complete the promise
+      // We explicitly do not fulfil the promise
       // when the last request for which we have a
       // mock is seen.
       //

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -231,6 +231,63 @@ class UnexpectedMitmMocker {
       mitm.disable();
     }
 
+    function handleRequest(req, metadata, spec) {
+      return consumeReadableStream(req, { skipConcat: true }).then(result => {
+        const properties = Object.assign(
+          {
+            method: req.method,
+            path: req.url,
+            protocolName: 'HTTP',
+            protocolVersion: req.httpVersion,
+            headers: req.headers,
+            unchunkedBody: Buffer.concat(result.body)
+          },
+          metadata
+        );
+        const request = new messy.HttpRequest(properties);
+
+        return {
+          request,
+          error: result.error,
+          chunks: result.body,
+          properties,
+          spec
+        };
+      });
+    }
+
+    function assertExchange(requestStruct, responseStruct) {
+      const mockRequest = requestStruct.request;
+      const exchange = new messy.HttpExchange({ request: mockRequest });
+
+      if (responseStruct === null) {
+        // leave everything unset for "<no response>"
+      } else if (responseStruct.response) {
+        exchange.response = responseStruct.response;
+      } else if (responseStruct.error) {
+        exchange.response = responseStruct.error;
+      }
+
+      let spec = null;
+      // only attempt request validation with a mock
+      if (requestStruct.spec) {
+        spec = { request: requestStruct.spec };
+      }
+
+      // We explicitly do not complete the promise
+      // when the last request for which we have a
+      // mock is seen.
+      //
+      // Instead simply record any exchanges that
+      // passed through and defer the resolution or
+      // rejection to the handler functions attached
+      // to the delegated assertion execution below.
+      timeline.push({
+        exchange,
+        spec
+      });
+    }
+
     return new Promise((resolve, reject) => {
       mitm.on(
         'request',
@@ -282,7 +339,7 @@ class UnexpectedMitmMocker {
           nextRequestDescriptionIndex += 1;
           const hasRequestDescription = !!requestDescription;
 
-          let requestProperties;
+          let requestStruct;
           let expectedRequestProperties;
 
           const responseProperties = hasRequestDescription
@@ -291,31 +348,27 @@ class UnexpectedMitmMocker {
 
           Promise.resolve()
             .then(() => {
+              if (!hasRequestDescription) {
+                return;
+              }
+
               expectedRequestProperties = resolveExpectedRequestProperties(
                 requestDescription && requestDescription.request
               );
             })
-            .then(() => consumeReadableStream(req, { skipConcat: true }))
+            .then(() => handleRequest(req, metadata, expectedRequestProperties))
             .then(result => {
-              if (result.error) {
+              // make available for use further down the promise chain
+              requestStruct = result;
+
+              if (requestStruct.error) {
                 // TODO: Consider adding support for recording this (the request erroring out while we're consuming it)
-                throw result.error;
+                throw requestStruct.error;
               }
-              requestProperties = _.extend(
-                {
-                  method: req.method,
-                  path: req.url,
-                  protocolName: 'HTTP',
-                  protocolVersion: req.httpVersion,
-                  headers: req.headers,
-                  unchunkedBody: Buffer.concat(result.body)
-                },
-                metadata
-              );
 
               if (!hasRequestDescription) {
                 // there was no mock so arrange "<no response>"
-                assertMockResponse(null);
+                assertExchange(requestStruct, null);
 
                 // We wish to cause the generation of a diff
                 // so we arrange to enter our 'success' path
@@ -341,7 +394,7 @@ class UnexpectedMitmMocker {
 
                 // read stream data from the buffered chunks
                 req._read = function() {
-                  this.push(result.body.shift() || null);
+                  this.push(requestStruct.chunks.shift() || null);
                 };
 
                 // call response function inside a promise to catch exceptions
@@ -363,18 +416,15 @@ class UnexpectedMitmMocker {
                 return getMockResponse(responseProperties);
               }
             })
-            .then(result => {
-              const mockResponse = result.response;
-              const mockResponseError = result.error;
-
-              if (!(mockResponse || mockResponseError)) {
+            .then(responseStruct => {
+              if (!(responseStruct.response || responseStruct.error)) {
                 return;
               }
 
               return Promise.resolve()
                 .then(() => {
                   const assertionMockRequest = new messy.HttpRequest(
-                    requestProperties
+                    requestStruct.properties
                   );
                   trimHeadersLower(assertionMockRequest);
 
@@ -382,14 +432,12 @@ class UnexpectedMitmMocker {
                   return expect(
                     assertionMockRequest,
                     'to satisfy',
-                    expectedRequestProperties
+                    requestStruct.spec
                   );
                 })
-                .then(() => {
-                  deliverMockResponse(mockResponse, mockResponseError);
-                })
+                .then(() => deliverMockResponse(responseStruct))
                 .catch(e => {
-                  assertMockResponse(mockResponse, mockResponseError);
+                  assertExchange(requestStruct, responseStruct);
                   throw new errors.EarlyExitError(
                     'Seen request did not match the expected request.'
                   );
@@ -412,36 +460,9 @@ class UnexpectedMitmMocker {
               reject(e);
             });
 
-          function assertMockResponse(mockResponse, mockResponseError) {
-            const mockRequest = new messy.HttpRequest(requestProperties);
-            const exchange = new messy.HttpExchange({ request: mockRequest });
-            if (mockResponse) {
-              exchange.response = mockResponse;
-            } else if (mockResponseError) {
-              exchange.response = mockResponseError;
-            }
-
-            let spec = null;
-            // only attempt request validation with a mock
-            if (hasRequestDescription) {
-              spec = { request: expectedRequestProperties };
-            }
-
-            // We explicitly do not complete the promise
-            // when the last request for which we have a
-            // mock is seen.
-            //
-            // Instead simply record any exchanges that
-            // passed through and defer the resolution or
-            // rejection to the handler functions attached
-            // to the delegated assertion execution below.
-            timeline.push({
-              exchange,
-              spec
-            });
-          }
-
-          function deliverMockResponse(mockResponse, mockResponseError) {
+          function deliverMockResponse(responseStruct) {
+            const mockResponse = responseStruct.response;
+            const mockResponseError = responseStruct.error;
             setImmediate(() => {
               let nonEmptyMockResponse = false;
               if (mockResponse) {
@@ -469,7 +490,7 @@ class UnexpectedMitmMocker {
               if (mockResponseError) {
                 setImmediate(() => {
                   clientSocket.emit('error', mockResponseError);
-                  assertMockResponse(mockResponse, mockResponseError);
+                  assertExchange(requestStruct, responseStruct);
                 });
               } else {
                 res.end();
@@ -480,8 +501,8 @@ class UnexpectedMitmMocker {
           // Hook the final write and immediately assert the request.
           // Note this occurs prior to it being written on the wire.
           observeResponse(res).then(rawBuffer => {
-            const mockResponse = createMockResponse(rawBuffer);
-            assertMockResponse(mockResponse);
+            const response = createMockResponse(rawBuffer);
+            assertExchange(requestStruct, { response });
           });
         })
       );


### PR DESCRIPTION
This commit takes a big step towards clarifying the internal state
within the mocker. Introduce objects for the multiple pieces of
information we track about the request and response making uses
of values much clearer.

One neat piece of fallout from this is request consumption becomes
contained within the single handleRequest() method. In addition the
addition of exchanges to the timeline does not need to be a closure
within the request serializer so moves up as an assertExchange().