### PR TITLE
Reduce surface area and get us down to a single header trim function.

### DIFF
--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -12,10 +12,9 @@ const consumeReadableStream = require('./consumeReadableStream');
 const createMessyResponse = require('./createMessyResponse');
 const createSerializedRequestHandler = require('./createSerializedRequestHandler');
 const errors = require('./errors');
-const formatHeaderObj = require('./formatHeaderObj');
 const isBodyJson = require('./isBodyJson');
 const resolveExpectedRequestProperties = require('./resolveExpectedRequestProperties');
-const trimHeadersLower = require('./trimHeadersLower');
+const trimMessyHeaders = require('./trimMessyHeaders');
 
 const expect = unexpected.clone().use(unexpectedMessy);
 
@@ -177,9 +176,7 @@ function trimMockResponse(mockResponse) {
   responseProperties.statusMessage = mockResponse.statusMessage;
   responseProperties.protocolName = mockResponse.protocolName;
   responseProperties.protocolVersion = mockResponse.protocolVersion;
-  responseProperties.headers = formatHeaderObj(
-    mockResponse.headers.valuesByName
-  );
+  responseProperties.headers = mockResponse.headers.toJSON();
 
   if (mockResponse.body) {
     // read out the messy decoded body
@@ -415,7 +412,7 @@ class UnexpectedMitmMocker {
                   const assertionMockRequest = new messy.HttpRequest(
                     requestStruct.properties
                   );
-                  trimHeadersLower(assertionMockRequest);
+                  trimMessyHeaders(assertionMockRequest.headers);
 
                   expect.errorMode = 'default';
                   return expect(

--- a/lib/checkTimeline.js
+++ b/lib/checkTimeline.js
@@ -1,4 +1,4 @@
-const trimHeadersLower = require('./trimHeadersLower');
+const trimMessyHeaders = require('./trimMessyHeaders');
 
 module.exports = function checkTimeline({ timeline, fulfilmentValue }) {
   let lastEventOrError = null;
@@ -18,7 +18,7 @@ module.exports = function checkTimeline({ timeline, fulfilmentValue }) {
       // event & spec
       const failedEvent = timeline[timeline.length - 2];
       const failedExchange = failedEvent.exchange;
-      trimHeadersLower(failedExchange.request);
+      trimMessyHeaders(failedExchange.request.headers);
 
       lastEventOrError.data = {
         failedExchange: failedExchange,

--- a/lib/formatHeaderObj.js
+++ b/lib/formatHeaderObj.js
@@ -1,9 +1,0 @@
-const messy = require('messy');
-
-module.exports = function formatHeaderObj(headerObj) {
-  const result = {};
-  Object.keys(headerObj).forEach(headerName => {
-    result[messy.formatHeaderName(headerName)] = headerObj[headerName];
-  });
-  return result;
-};

--- a/lib/formatRecordedExchange.js
+++ b/lib/formatRecordedExchange.js
@@ -1,5 +1,5 @@
 const isBodyTextual = require('./isBodyTextual');
-const trimHeaders = require('./trimHeaders');
+const trimMessyHeaders = require('./trimMessyHeaders');
 
 function asInteger(value) {
   return typeof value === 'string' ? parseInt(value, 10) : value;
@@ -28,9 +28,10 @@ function trimMessage(messageOrError) {
   }
 
   if (serialisedMessage.headers) {
-    trimHeaders(serialisedMessage);
-    if (Object.keys(serialisedMessage.headers).length > 0) {
-      output.headers = serialisedMessage.headers;
+    const headers = message.headers.clone();
+    trimMessyHeaders(headers);
+    if (Object.keys(headers.valuesByName).length > 0) {
+      output.headers = headers.toJSON();
     }
   }
 

--- a/lib/formatRecordedExchange.js
+++ b/lib/formatRecordedExchange.js
@@ -30,7 +30,7 @@ function trimMessage(messageOrError) {
   if (serialisedMessage.headers) {
     const headers = message.headers.clone();
     trimMessyHeaders(headers);
-    if (Object.keys(headers.valuesByName).length > 0) {
+    if (headers.getNamesLowerCase().length > 0) {
       output.headers = headers.toJSON();
     }
   }

--- a/lib/trimHeaders.js
+++ b/lib/trimHeaders.js
@@ -1,6 +1,0 @@
-module.exports = function trimHeaders(message) {
-  delete message.headers['Content-Length'];
-  delete message.headers['Transfer-Encoding'];
-  delete message.headers.Connection;
-  delete message.headers.Date;
-};

--- a/lib/trimHeadersLower.js
+++ b/lib/trimHeadersLower.js
@@ -1,8 +1,0 @@
-module.exports = function trimHeadersLower(message) {
-  delete message.headers.valuesByName['content-length'];
-  delete message.headers.valuesByName['transfer-encoding'];
-  delete message.headers.valuesByName.connection;
-  delete message.headers.valuesByName.date;
-
-  return message;
-};

--- a/lib/trimMessyHeaders.js
+++ b/lib/trimMessyHeaders.js
@@ -1,6 +1,6 @@
 module.exports = function trimMessyHeaders(headers) {
-  delete headers.remove('content-length');
-  delete headers.remove('transfer-encoding');
-  delete headers.remove('connection');
-  delete headers.remove('date');
+  headers.remove('Content-Length');
+  headers.remove('Transfer-Encoding');
+  headers.remove('Connection');
+  headers.remove('Date');
 };

--- a/lib/trimMessyHeaders.js
+++ b/lib/trimMessyHeaders.js
@@ -1,0 +1,6 @@
+module.exports = function trimMessyHeaders(headers) {
+  delete headers.valuesByName['content-length'];
+  delete headers.valuesByName['transfer-encoding'];
+  delete headers.valuesByName.connection;
+  delete headers.valuesByName.date;
+};

--- a/lib/trimMessyHeaders.js
+++ b/lib/trimMessyHeaders.js
@@ -1,6 +1,6 @@
 module.exports = function trimMessyHeaders(headers) {
-  delete headers.valuesByName['content-length'];
-  delete headers.valuesByName['transfer-encoding'];
-  delete headers.valuesByName.connection;
-  delete headers.valuesByName.date;
+  delete headers.remove('content-length');
+  delete headers.remove('transfer-encoding');
+  delete headers.remove('connection');
+  delete headers.remove('date');
 };

--- a/lib/unexpectedMitm.js
+++ b/lib/unexpectedMitm.js
@@ -6,11 +6,10 @@ const callsite = require('callsite');
 const detectIndent = require('detect-indent');
 
 const checkTimeline = require('./checkTimeline');
-const formatHeaderObj = require('./formatHeaderObj');
 const formatRecordedExchange = require('./formatRecordedExchange');
 const isBodyJson = require('./isBodyJson');
 const performRequest = require('./performRequest');
-const trimHeaders = require('./trimHeaders');
+const trimMessyHeaders = require('./trimMessyHeaders');
 const UnexpectedMitmMocker = require('./UnexpectedMitmMocker');
 const UnexpectedMitmRecorder = require('./UnexpectedMitmRecorder');
 
@@ -61,11 +60,13 @@ function determineCallsite(stack) {
 }
 
 function responseForVerification(response, validationBlock) {
-  // arrange to use formatted headers
-  response.headers = formatHeaderObj(response.headers);
+  const headers = new messy.Headers(response.headers);
 
   // remove superfluous headers from the response
-  trimHeaders(response);
+  trimMessyHeaders(headers);
+
+  // call messy to output formatted headers
+  response.headers = headers.toJSON();
 
   // call messy for decoding of text values
   const messyMessage = new messy.Message({


### PR DESCRIPTION
Leverage messy headers objects and their serialisation capabilities
to define a single trim function that operates on such objects. Any
places we need this we simply instantiate, trim and then serialise.