### PR TITLE
Pluggable mock strategy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,5 +16,13 @@
         "ignoreReadBeforeAssign": false
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["test/**/*.js"],
+      "rules": {
+        "no-new": "off"
+      }
+    }
+  ]
 }

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -195,11 +195,15 @@ class UnexpectedMitmMocker {
     this.timeline = null;
     this.fulfilmentValue = null;
 
-    const requestDescriptions = options.requestDescriptions;
-    if (!Array.isArray(requestDescriptions)) {
-      throw new Error('UnexpectedMitmMocker: missing request descriptions');
+    if (options.strategy) {
+      this.strategy = options.strategy;
+    } else if (Array.isArray(options.requestDescriptions)) {
+      this.strategy = new OrderedMockStrategy(options.requestDescriptions);
+    } else {
+      throw new Error(
+        'UnexpectedMitmMocker: missing strategy or request descriptions'
+      );
     }
-    this.strategy = new OrderedMockStrategy(requestDescriptions);
   }
 
   mock(consumptionFunction) {

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -329,8 +329,6 @@ class UnexpectedMitmMocker {
             )
           );
 
-          const hasRequestDescription = this.strategy.hasDescriptionsRemaining();
-
           let requestStruct;
           let responseProperties;
 
@@ -339,10 +337,6 @@ class UnexpectedMitmMocker {
             .then(result => {
               // make available for use further down the promise chain
               requestStruct = result;
-
-              if (!hasRequestDescription) {
-                return null;
-              }
 
               return this.strategy.nextDescriptionForIncomingRequest(
                 result.request

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -339,7 +339,7 @@ class UnexpectedMitmMocker {
               requestStruct = result;
 
               return this.strategy.nextDescriptionForIncomingRequest(
-                result.request
+                requestStruct
               );
             })
             .then(requestDescription => {

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -219,7 +219,7 @@ class UnexpectedMitmMocker {
       mitm.disable();
     }
 
-    function handleRequest(req, metadata, spec) {
+    function handleRequest(req, metadata) {
       return consumeReadableStream(req, { skipConcat: true }).then(result => {
         const properties = {
           method: req.method,
@@ -237,7 +237,7 @@ class UnexpectedMitmMocker {
           error: result.error,
           chunks: result.body,
           properties,
-          spec
+          spec: undefined
         };
       });
     }
@@ -333,16 +333,18 @@ class UnexpectedMitmMocker {
             : undefined;
 
           Promise.resolve()
-            .then(() => {
-              if (!hasRequestDescription) {
-                return;
+            .then(() => handleRequest(req, metadata))
+            .then(result => {
+              if (hasRequestDescription) {
+                expectedRequestProperties = resolveExpectedRequestProperties(
+                  requestDescription && requestDescription.request
+                );
+                // update the request with the spec it needs to satisfy
+                result.spec = expectedRequestProperties;
               }
 
-              expectedRequestProperties = resolveExpectedRequestProperties(
-                requestDescription && requestDescription.request
-              );
+              return result;
             })
-            .then(() => handleRequest(req, metadata, expectedRequestProperties))
             .then(result => {
               // make available for use further down the promise chain
               requestStruct = result;

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -189,11 +189,16 @@ function trimMockResponse(mockResponse) {
 
 class UnexpectedMitmMocker {
   constructor(options) {
+    options = options || {};
+
     this.strategy = null;
     this.timeline = null;
     this.fulfilmentValue = null;
 
-    const requestDescriptions = options.requestDescriptions || [];
+    const requestDescriptions = options.requestDescriptions;
+    if (!Array.isArray(requestDescriptions)) {
+      throw new Error('UnexpectedMitmMocker: missing request descriptions');
+    }
     this.strategy = new OrderedMockStrategy(requestDescriptions);
   }
 

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -13,6 +13,7 @@ const createMessyResponse = require('./createMessyResponse');
 const createSerializedRequestHandler = require('./createSerializedRequestHandler');
 const errors = require('./errors');
 const isBodyJson = require('./isBodyJson');
+const OrderedMockStrategy = require('./mockstrategies/OrderedMockStrategy');
 const resolveExpectedRequestProperties = require('./resolveExpectedRequestProperties');
 const trimMessyHeaders = require('./trimMessyHeaders');
 
@@ -188,18 +189,17 @@ function trimMockResponse(mockResponse) {
 
 class UnexpectedMitmMocker {
   constructor(options) {
-    this.requestDescriptions = options.requestDescriptions || [];
+    this.strategy = null;
     this.timeline = null;
     this.fulfilmentValue = null;
+
+    const requestDescriptions = options.requestDescriptions || [];
+    this.strategy = new OrderedMockStrategy(requestDescriptions);
   }
 
   mock(consumptionFunction) {
     const that = this;
-    const requestDescriptions = this.requestDescriptions;
     const mitm = createMitm();
-
-    // Keep track of the current requestDescription
-    let nextRequestDescriptionIndex = 0;
 
     // Keep track of the http/https agents that we have seen
     // during the test so we can clean up afterwards:
@@ -320,30 +320,30 @@ class UnexpectedMitmMocker {
             )
           );
 
-          const requestDescription =
-            requestDescriptions[nextRequestDescriptionIndex];
-          nextRequestDescriptionIndex += 1;
-          const hasRequestDescription = !!requestDescription;
+          const hasRequestDescription = this.strategy.hasDescriptionsRemaining();
 
           let requestStruct;
+          let responseProperties;
           let expectedRequestProperties;
-
-          const responseProperties = hasRequestDescription
-            ? requestDescription.response
-            : undefined;
 
           Promise.resolve()
             .then(() => handleRequest(req, metadata))
             .then(result => {
-              if (hasRequestDescription) {
-                expectedRequestProperties = resolveExpectedRequestProperties(
-                  requestDescription && requestDescription.request
-                );
-                // update the request with the spec it needs to satisfy
-                result.spec = expectedRequestProperties;
+              if (!hasRequestDescription) {
+                return result;
               }
-
-              return result;
+              return this.strategy
+                .nextDescriptionForIncomingRequest(result.request)
+                .then(requestDescription => {
+                  expectedRequestProperties = resolveExpectedRequestProperties(
+                    requestDescription && requestDescription.request
+                  );
+                  // set the response to be constructed based on the strategy
+                  responseProperties = requestDescription.response;
+                  // update the request with the spec it needs to satisfy
+                  result.spec = expectedRequestProperties;
+                })
+                .then(() => result);
             })
             .then(result => {
               // make available for use further down the promise chain
@@ -514,24 +514,27 @@ class UnexpectedMitmMocker {
           // Where the driving assertion resolves we must check
           // if any mocks still exist. If so, we add them to the
           // set of expected exchanges and resolve the promise.
-          const hasRemainingRequestDescriptions =
-            nextRequestDescriptionIndex < requestDescriptions.length;
+          const hasRemainingRequestDescriptions = this.strategy.hasDescriptionsRemaining();
           if (hasRemainingRequestDescriptions) {
             // exhaust remaining mocks using a promises chain
-            return (function nextItem() {
-              const remainingDescription =
-                requestDescriptions[nextRequestDescriptionIndex];
-              nextRequestDescriptionIndex += 1;
-              if (remainingDescription) {
+            const nextItem = () => {
+              if (this.strategy.hasDescriptionsRemaining()) {
                 let expectedRequestProperties;
+                let responseProperties;
 
                 return Promise.resolve()
                   .then(() => {
-                    expectedRequestProperties = resolveExpectedRequestProperties(
-                      remainingDescription.request
-                    );
+                    return this.strategy
+                      .firstDescriptionRemaining()
+                      .then(remainingDescription => {
+                        expectedRequestProperties = resolveExpectedRequestProperties(
+                          remainingDescription && remainingDescription.request
+                        );
+                        // set the response to be constructed based on the strategy
+                        responseProperties = remainingDescription.response;
+                      });
                   })
-                  .then(() => getMockResponse(remainingDescription.response))
+                  .then(() => getMockResponse(responseProperties))
                   .then(result => {
                     const spec = {
                       request: expectedRequestProperties,
@@ -546,7 +549,8 @@ class UnexpectedMitmMocker {
               } else {
                 throw new errors.UnexercisedMocksError();
               }
-            })();
+            };
+            return nextItem();
           } else {
             resolve(fulfilmentValue);
           }

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -515,25 +515,29 @@ class UnexpectedMitmMocker {
           // Where the driving assertion resolves we must check
           // if any mocks still exist. If so, we add them to the
           // set of expected exchanges and resolve the promise.
-          const hasRemainingRequestDescriptions = this.strategy.hasDescriptionsRemaining();
-          if (hasRemainingRequestDescriptions) {
-            // exhaust remaining mocks using a promises chain
-            const nextItem = () => {
-              if (this.strategy.hasDescriptionsRemaining()) {
+          return this.strategy
+            .firstDescriptionRemaining()
+            .then(firstUnexercisedDescription => {
+              if (!firstUnexercisedDescription) {
+                resolve(fulfilmentValue);
+              }
+
+              // exhaust remaining mocks using a promises chain
+              const exhaustDescription = remainingDescription => {
+                if (!remainingDescription) {
+                  throw new errors.UnexercisedMocksError();
+                }
+
                 let expectedRequestProperties;
                 let responseProperties;
 
                 return Promise.resolve()
                   .then(() => {
-                    return this.strategy
-                      .firstDescriptionRemaining()
-                      .then(remainingDescription => {
-                        expectedRequestProperties = resolveExpectedRequestProperties(
-                          remainingDescription && remainingDescription.request
-                        );
-                        // set the response to be constructed based on the strategy
-                        responseProperties = remainingDescription.response;
-                      });
+                    expectedRequestProperties = resolveExpectedRequestProperties(
+                      remainingDescription && remainingDescription.request
+                    );
+                    // set the response to be constructed based on the strategy
+                    responseProperties = remainingDescription.response;
                   })
                   .then(() => getMockResponse(responseProperties))
                   .then(result => {
@@ -545,16 +549,14 @@ class UnexpectedMitmMocker {
 
                     timeline.push({ spec });
 
-                    return nextItem();
+                    return this.strategy
+                      .firstDescriptionRemaining()
+                      .then(exhaustDescription);
                   });
-              } else {
-                throw new errors.UnexercisedMocksError();
-              }
-            };
-            return nextItem();
-          } else {
-            resolve(fulfilmentValue);
-          }
+              };
+
+              return exhaustDescription(firstUnexercisedDescription);
+            });
         })
         .catch(e => {
           timeline.push(e);

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -15,7 +15,6 @@ const errors = require('./errors');
 const isBodyJson = require('./isBodyJson');
 const OrderedMockStrategy = require('./mockstrategies/OrderedMockStrategy');
 const resolveExpectedRequestProperties = require('./resolveExpectedRequestProperties');
-const trimMessyHeaders = require('./trimMessyHeaders');
 
 const expect = unexpected.clone().use(unexpectedMessy);
 
@@ -331,6 +330,9 @@ class UnexpectedMitmMocker {
 
           let requestStruct;
           let responseProperties;
+          let responseStruct;
+
+          let __earlyExit = null;
 
           Promise.resolve()
             .then(() => handleRequest(req, metadata))
@@ -338,9 +340,21 @@ class UnexpectedMitmMocker {
               // make available for use further down the promise chain
               requestStruct = result;
 
-              return this.strategy.nextDescriptionForIncomingRequest(
-                requestStruct
-              );
+              return this.strategy
+                .nextDescriptionForIncomingRequest(requestStruct)
+                .catch(err => {
+                  if (err.name === 'EarlyExitError') {
+                    __earlyExit = err;
+                    const requestDescription = err.data;
+                    // update the request with the spec it needs to satisfy
+                    requestStruct.spec = resolveExpectedRequestProperties(
+                      requestDescription && requestDescription.request
+                    );
+                    return requestDescription;
+                  }
+
+                  throw err;
+                });
             })
             .then(requestDescription => {
               if (requestStruct.error) {
@@ -363,6 +377,10 @@ class UnexpectedMitmMocker {
                 // resolve()d thus the rejection of the former
                 // is effectively ignored and we proceed with
                 // our output.
+
+                if (__earlyExit) {
+                  throw __earlyExit;
+                }
 
                 // cancel the delegated assertion
                 throw new errors.SawUnexpectedRequestsError(
@@ -405,32 +423,19 @@ class UnexpectedMitmMocker {
                 return getMockResponse(responseProperties);
               }
             })
-            .then(responseStruct => {
+            .then(result => {
+              responseStruct = result;
+
               if (!(responseStruct.response || responseStruct.error)) {
                 return;
               }
 
-              return Promise.resolve()
-                .then(() => {
-                  const assertionMockRequest = new messy.HttpRequest(
-                    requestStruct.properties
-                  );
-                  trimMessyHeaders(assertionMockRequest.headers);
+              if (__earlyExit) {
+                assertExchange(requestStruct, responseStruct);
+                throw __earlyExit;
+              }
 
-                  expect.errorMode = 'default';
-                  return expect(
-                    assertionMockRequest,
-                    'to satisfy',
-                    requestStruct.spec
-                  );
-                })
-                .then(() => deliverMockResponse(responseStruct))
-                .catch(e => {
-                  assertExchange(requestStruct, responseStruct);
-                  throw new errors.EarlyExitError(
-                    'Seen request did not match the expected request.'
-                  );
-                });
+              return deliverMockResponse(responseStruct);
             })
             .catch(e => {
               // Given an error occurs, the deferred assertion

--- a/lib/UnexpectedMitmMocker.js
+++ b/lib/UnexpectedMitmMocker.js
@@ -333,37 +333,28 @@ class UnexpectedMitmMocker {
 
           let requestStruct;
           let responseProperties;
-          let expectedRequestProperties;
 
           Promise.resolve()
             .then(() => handleRequest(req, metadata))
             .then(result => {
-              if (!hasRequestDescription) {
-                return result;
-              }
-              return this.strategy
-                .nextDescriptionForIncomingRequest(result.request)
-                .then(requestDescription => {
-                  expectedRequestProperties = resolveExpectedRequestProperties(
-                    requestDescription && requestDescription.request
-                  );
-                  // set the response to be constructed based on the strategy
-                  responseProperties = requestDescription.response;
-                  // update the request with the spec it needs to satisfy
-                  result.spec = expectedRequestProperties;
-                })
-                .then(() => result);
-            })
-            .then(result => {
               // make available for use further down the promise chain
               requestStruct = result;
 
+              if (!hasRequestDescription) {
+                return null;
+              }
+
+              return this.strategy.nextDescriptionForIncomingRequest(
+                result.request
+              );
+            })
+            .then(requestDescription => {
               if (requestStruct.error) {
                 // TODO: Consider adding support for recording this (the request erroring out while we're consuming it)
                 throw requestStruct.error;
               }
 
-              if (!hasRequestDescription) {
+              if (!requestDescription) {
                 // there was no mock so arrange "<no response>"
                 assertExchange(requestStruct, null);
 
@@ -384,6 +375,13 @@ class UnexpectedMitmMocker {
                   'unexpected-mitm: Saw unexpected requests.'
                 );
               }
+
+              // update the request with the spec it needs to satisfy
+              requestStruct.spec = resolveExpectedRequestProperties(
+                requestDescription && requestDescription.request
+              );
+              // set the response to be constructed based on the strategy
+              responseProperties = requestDescription.response;
 
               if (typeof responseProperties === 'function') {
                 // reset the readable req stream state

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -4,6 +4,7 @@ const expect = require('unexpected')
 const messy = require('messy');
 
 const errors = require('../errors');
+const resolveExpectedRequestProperties = require('../resolveExpectedRequestProperties');
 const trimMessyHeaders = require('../trimMessyHeaders');
 
 module.exports = class OrderedMockStrategy {
@@ -42,8 +43,13 @@ module.exports = class OrderedMockStrategy {
         );
         trimMessyHeaders(assertionMockRequest.headers);
 
+        // update the request with the spec it needs to satisfy
+        const assertionSeenSpec = resolveExpectedRequestProperties(
+          description.request
+        );
+
         expect.errorMode = 'default';
-        return expect(assertionMockRequest, 'to satisfy', requestStruct.spec);
+        return expect(assertionMockRequest, 'to satisfy', assertionSeenSpec);
       })
       .then(() => description)
       .catch(e => {

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -30,6 +30,11 @@ module.exports = class OrderedMockStrategy {
     ];
     this.nextRequestDescriptionIndex += 1;
 
+    if (!requestStruct) {
+      // skip early exit when exhausting requests
+      return Promise.resolve(description);
+    }
+
     return Promise.resolve()
       .then(() => {
         const assertionMockRequest = new messy.HttpRequest(

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -1,0 +1,22 @@
+module.exports = class OrderedMockStrategy {
+  constructor(requestDescriptions) {
+    this.requestDescriptions = requestDescriptions;
+    this.nextRequestDescriptionIndex = 0;
+  }
+
+  firstDescriptionRemaining() {
+    return this.nextDescriptionForIncomingRequest();
+  }
+
+  hasDescriptionsRemaining() {
+    return this.nextRequestDescriptionIndex < this.requestDescriptions.length;
+  }
+
+  nextDescriptionForIncomingRequest() {
+    const description = this.requestDescriptions[
+      this.nextRequestDescriptionIndex
+    ];
+    this.nextRequestDescriptionIndex += 1;
+    return Promise.resolve(description);
+  }
+};

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -13,6 +13,10 @@ module.exports = class OrderedMockStrategy {
   }
 
   nextDescriptionForIncomingRequest() {
+    if (!this.hasDescriptionsRemaining()) {
+      return Promise.resolve(null);
+    }
+
     const description = this.requestDescriptions[
       this.nextRequestDescriptionIndex
     ];

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -4,16 +4,16 @@ module.exports = class OrderedMockStrategy {
     this.nextRequestDescriptionIndex = 0;
   }
 
+  get isEmpty() {
+    return this.nextRequestDescriptionIndex >= this.requestDescriptions.length;
+  }
+
   firstDescriptionRemaining() {
     return this.nextDescriptionForIncomingRequest();
   }
 
-  hasDescriptionsRemaining() {
-    return this.nextRequestDescriptionIndex < this.requestDescriptions.length;
-  }
-
   nextDescriptionForIncomingRequest() {
-    if (!this.hasDescriptionsRemaining()) {
+    if (this.isEmpty) {
       return Promise.resolve(null);
     }
 

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -13,7 +13,7 @@ module.exports = class OrderedMockStrategy {
     this.nextRequestDescriptionIndex = 0;
   }
 
-  get isEmpty() {
+  get isExhausted() {
     return this.nextRequestDescriptionIndex >= this.requestDescriptions.length;
   }
 
@@ -22,7 +22,7 @@ module.exports = class OrderedMockStrategy {
   }
 
   nextDescriptionForIncomingRequest(requestStruct) {
-    if (this.isEmpty) {
+    if (this.isExhausted) {
       return Promise.resolve(null);
     }
 

--- a/lib/mockstrategies/OrderedMockStrategy.js
+++ b/lib/mockstrategies/OrderedMockStrategy.js
@@ -1,3 +1,11 @@
+const expect = require('unexpected')
+  .clone()
+  .use(require('unexpected-messy'));
+const messy = require('messy');
+
+const errors = require('../errors');
+const trimMessyHeaders = require('../trimMessyHeaders');
+
 module.exports = class OrderedMockStrategy {
   constructor(requestDescriptions) {
     this.requestDescriptions = requestDescriptions;
@@ -12,7 +20,7 @@ module.exports = class OrderedMockStrategy {
     return this.nextDescriptionForIncomingRequest();
   }
 
-  nextDescriptionForIncomingRequest() {
+  nextDescriptionForIncomingRequest(requestStruct) {
     if (this.isEmpty) {
       return Promise.resolve(null);
     }
@@ -21,6 +29,23 @@ module.exports = class OrderedMockStrategy {
       this.nextRequestDescriptionIndex
     ];
     this.nextRequestDescriptionIndex += 1;
-    return Promise.resolve(description);
+
+    return Promise.resolve()
+      .then(() => {
+        const assertionMockRequest = new messy.HttpRequest(
+          requestStruct.properties
+        );
+        trimMessyHeaders(assertionMockRequest.headers);
+
+        expect.errorMode = 'default';
+        return expect(assertionMockRequest, 'to satisfy', requestStruct.spec);
+      })
+      .then(() => description)
+      .catch(e => {
+        throw new errors.EarlyExitError({
+          message: 'Seen request did not match the expected request.',
+          data: description
+        });
+      });
   }
 };

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -59,7 +59,8 @@ describe('UnexpectedMitmMocker', () => {
   describe('when there are no remaining requests', () => {
     it('should reject with an unexpected requests error', () => {
       const strategy = {
-        hasDescriptionsRemaining: () => false
+        hasDescriptionsRemaining: () => false,
+        nextDescriptionForIncomingRequest: () => Promise.resolve(null)
       };
       const mocker = new UnexpectedMitmMocker({ strategy });
 
@@ -79,15 +80,7 @@ describe('UnexpectedMitmMocker', () => {
   describe('when the request does not match expectations', () => {
     it('should reject with an unexpected requests error', () => {
       const strategy = {
-        // return true for the first call
-        hasDescriptionsRemaining: (() => {
-          let unread = true;
-          return () => {
-            const ret = unread;
-            unread = false;
-            return ret;
-          };
-        })(),
+        hasDescriptionsRemaining: () => false,
         nextDescriptionForIncomingRequest: () =>
           Promise.resolve({
             request: {

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -56,6 +56,39 @@ describe('UnexpectedMitmMocker', () => {
     });
   });
 
+  it('should call nextDescriptionForIncomingRequest with the correct args', () => {
+    let nextDescriptionForIncomingRequestArgs;
+    const strategy = {
+      firstDescriptionRemaining: () => Promise.resolve(null),
+      nextDescriptionForIncomingRequest: (...args) => {
+        nextDescriptionForIncomingRequestArgs = args;
+
+        return Promise.resolve(null);
+      }
+    };
+    const mocker = new UnexpectedMitmMocker({ strategy });
+
+    return mocker
+      .mock(() => {
+        return issueGetAndConsume('http://example.com/foo').catch(e => {});
+      })
+      .then(({ fulfilmentValue, timeline }) => {
+        expect(
+          nextDescriptionForIncomingRequestArgs,
+          'to exhaustively satisfy',
+          [
+            {
+              request: expect.it('to be a', messy.HttpRequest),
+              error: undefined,
+              chunks: expect.it('to be an array'),
+              properties: expect.it('to be an object'),
+              spec: undefined
+            }
+          ]
+        );
+      });
+  });
+
   describe('when handling a request', () => {
     it('should reject with an unexpected requests error', () => {
       const strategy = {

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -1,0 +1,24 @@
+const expect = require('unexpected');
+
+const OrderedMockStrategy = require('../lib/mockstrategies/OrderedMockStrategy');
+const UnexpectedMitmMocker = require('../lib/UnexpectedMitmMocker');
+
+describe('UnexpectedMitmMocker', () => {
+  it('should throw if not supplied request descriptions', () => {
+    expect(
+      () => {
+        new UnexpectedMitmMocker();
+      },
+      'to throw',
+      'UnexpectedMitmMocker: missing request descriptions'
+    );
+  });
+
+  it('should create an ordered mock strategy by default', () => {
+    const mocker = new UnexpectedMitmMocker({ requestDescriptions: [] });
+
+    expect(mocker, 'to satisfy', {
+      strategy: expect.it('to be an', OrderedMockStrategy)
+    });
+  });
+});

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -4,13 +4,13 @@ const OrderedMockStrategy = require('../lib/mockstrategies/OrderedMockStrategy')
 const UnexpectedMitmMocker = require('../lib/UnexpectedMitmMocker');
 
 describe('UnexpectedMitmMocker', () => {
-  it('should throw if not supplied request descriptions', () => {
+  it('should throw if supplied no strategy or request descriptions', () => {
     expect(
       () => {
         new UnexpectedMitmMocker();
       },
       'to throw',
-      'UnexpectedMitmMocker: missing request descriptions'
+      'UnexpectedMitmMocker: missing strategy or request descriptions'
     );
   });
 
@@ -19,6 +19,15 @@ describe('UnexpectedMitmMocker', () => {
 
     expect(mocker, 'to satisfy', {
       strategy: expect.it('to be an', OrderedMockStrategy)
+    });
+  });
+
+  it('should create an mocker with the specific strategy', () => {
+    const strategy = {};
+    const mocker = new UnexpectedMitmMocker({ strategy });
+
+    expect(mocker, 'to satisfy', {
+      strategy: expect.it('to be', strategy)
     });
   });
 });

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -56,6 +56,25 @@ describe('UnexpectedMitmMocker', () => {
     });
   });
 
+  describe('when handling a request', () => {
+    it('should reject with an unexpected requests error', () => {
+      const strategy = {
+        firstDescriptionRemaining: () => Promise.resolve(null),
+        nextDescriptionForIncomingRequest: () =>
+          Promise.reject(new Error('fail'))
+      };
+      const mocker = new UnexpectedMitmMocker({ strategy });
+
+      return mocker
+        .mock(() => {
+          return issueGetAndConsume('http://example.com/foo').catch(e => {});
+        })
+        .then(({ fulfilmentValue, timeline }) => {
+          expect(timeline, 'to satisfy', [new Error('fail')]);
+        });
+    });
+  });
+
   describe('when there are no remaining requests', () => {
     it('should reject with an unexpected requests error', () => {
       const strategy = {

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -134,11 +134,7 @@ describe('UnexpectedMitmMocker', () => {
       const strategy = {
         firstDescriptionRemaining: () => Promise.resolve(null),
         nextDescriptionForIncomingRequest: () =>
-          Promise.resolve({
-            request: {
-              url: '/bar'
-            }
-          })
+          Promise.reject(new errors.EarlyExitError())
       };
       const mocker = new UnexpectedMitmMocker({ strategy });
 

--- a/test/UnexpectedMitmMocker.js
+++ b/test/UnexpectedMitmMocker.js
@@ -59,7 +59,7 @@ describe('UnexpectedMitmMocker', () => {
   describe('when there are no remaining requests', () => {
     it('should reject with an unexpected requests error', () => {
       const strategy = {
-        hasDescriptionsRemaining: () => false,
+        firstDescriptionRemaining: () => Promise.resolve(null),
         nextDescriptionForIncomingRequest: () => Promise.resolve(null)
       };
       const mocker = new UnexpectedMitmMocker({ strategy });
@@ -80,7 +80,7 @@ describe('UnexpectedMitmMocker', () => {
   describe('when the request does not match expectations', () => {
     it('should reject with an unexpected requests error', () => {
       const strategy = {
-        hasDescriptionsRemaining: () => false,
+        firstDescriptionRemaining: () => Promise.resolve(null),
         nextDescriptionForIncomingRequest: () =>
           Promise.resolve({
             request: {

--- a/test/unexpectedMitm.js
+++ b/test/unexpectedMitm.js
@@ -40,6 +40,45 @@ function trimDiff(message) {
   return message;
 }
 
+// :scream_cat:
+function createGetAddrInfoError(host, port) {
+  var getaddrinfoError;
+  // Different versions of node have shuffled around the properties of error instances:
+  var nodeJsVersion = process.version.replace(/^v/, '');
+  if (nodeJsVersion === '0.10.29') {
+    getaddrinfoError = new Error('getaddrinfo EADDRINFO');
+    getaddrinfoError.code = getaddrinfoError.errno = 'EADDRINFO';
+  } else if (semver.satisfies(nodeJsVersion, '>=0.12.0')) {
+    var message =
+      'getaddrinfo ENOTFOUND www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com';
+    if (semver.satisfies(nodeJsVersion, '>=9.7.0 <10')) {
+      // https://github.com/nodejs/node/issues/19716
+      getaddrinfoError = new Error();
+      getaddrinfoError.message = message;
+    } else {
+      getaddrinfoError = new Error(message);
+    }
+    if (
+      semver.satisfies(nodeJsVersion, '>=2.0.0') &&
+      semver.satisfies(nodeJsVersion, '<12')
+    ) {
+      getaddrinfoError.message += ` ${host}:${port}`;
+      getaddrinfoError.host = host;
+      getaddrinfoError.port = port;
+    }
+    getaddrinfoError.code = getaddrinfoError.errno = 'ENOTFOUND';
+    if (semver.satisfies(nodeJsVersion, '>=13')) {
+      getaddrinfoError.errno = -3008;
+    }
+    getaddrinfoError.hostname = 'www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com';
+  } else {
+    getaddrinfoError = new Error('getaddrinfo ENOTFOUND');
+    getaddrinfoError.code = getaddrinfoError.errno = 'ENOTFOUND';
+  }
+  getaddrinfoError.syscall = 'getaddrinfo';
+  return getaddrinfoError;
+}
+
 describe('unexpectedMitm', () => {
   const expect = require('unexpected')
     .clone()
@@ -2273,39 +2312,10 @@ describe('unexpectedMitm', () => {
     });
 
     it('should record an error', () => {
-      let expectedError;
-      // I do not know the exact version where this change was introduced. Hopefully this is enough to get
-      // it working on Travis (0.10.36 presently):
-      const nodeJsVersion = process.version.replace(/^v/, '');
-      if (nodeJsVersion === '0.10.29') {
-        expectedError = new Error('getaddrinfo EADDRINFO');
-        expectedError.code = expectedError.errno = 'EADDRINFO';
-      } else if (semver.satisfies(nodeJsVersion, '>=0.12.0')) {
-        const message =
-          'getaddrinfo ENOTFOUND www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com';
-        if (semver.satisfies(nodeJsVersion, '>=9.7.0 <10')) {
-          expectedError = new Error();
-          // explicitly set "message" to workaround an issue with enumerable properties
-          expectedError.message = message;
-        } else {
-          expectedError = new Error(message);
-        }
-        if (
-          semver.satisfies(nodeJsVersion, '>=2.0.0') &&
-          semver.satisfies(nodeJsVersion, '<12')
-        ) {
-          expectedError.message +=
-            ' www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com:80';
-          expectedError.host = 'www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com';
-          expectedError.port = 80;
-        }
-        expectedError.code = expectedError.errno = 'ENOTFOUND';
-        expectedError.hostname = 'www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com';
-      } else {
-        expectedError = new Error('getaddrinfo ENOTFOUND');
-        expectedError.code = expectedError.errno = 'ENOTFOUND';
-      }
-      expectedError.syscall = 'getaddrinfo';
+      const expectedError = createGetAddrInfoError(
+        'www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com',
+        80
+      );
       return expect(
         'http://www.icwqjecoiqwjecoiwqjecoiwqjceoiwq.com/',
         'with expected http recording',


### PR DESCRIPTION
This PR re-arranges the mocker internals so the decision making power about the next mock to run and whether there are any compatible mocks into "mock strategy" objects.

The changes here are primarily infrastructure and add the codepaths to call methods on the strategy object at the right times - as part of this, rejig the enforcing an ordered series of mocks turning it into the OrderedMockStrategy.